### PR TITLE
Propagate step counter through training epochs

### DIFF
--- a/proc/train.py
+++ b/proc/train.py
@@ -259,7 +259,7 @@ for epoch in range(cfg.start_epoch, epochs):
 	if cfg.distributed:
 		train_sampler.set_epoch(epoch)
 
-	train_one_epoch(
+	step = train_one_epoch(
 		model=model,
 		criterion=criterion,
 		optimizer=optimizer,

--- a/proc/util/train_loop.py
+++ b/proc/util/train_loop.py
@@ -78,6 +78,8 @@ def train_one_epoch(
 			lr_scheduler.step()
 			accum_loss = 0.0
 
+	return step
+
 
 def criterion(
 	pred: torch.Tensor,


### PR DESCRIPTION
## Summary
- Return `step` from `train_one_epoch` so the counter persists across epochs
- Capture updated `step` in `train.py` to pass into subsequent epochs

## Testing
- ⚠️ `python -m ruff check proc/util/train_loop.py proc/train.py` (fails: existing style issues)
- ⚠️ `python -m pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a576b3e354832b94ceb75c4edfdb35