### PR TITLE
Ensure segyio datasets release file handles

### DIFF
--- a/proc/train.py
+++ b/proc/train.py
@@ -98,6 +98,7 @@ n_val_item = (
 	else cfg.val_steps * cfg.batch_size * cfg.world_size
 )
 val_items = [val_src[i] for i in range(n_val_item)]
+val_src.close()
 
 
 class FrozenValDataset(Dataset):
@@ -373,5 +374,6 @@ for epoch in range(cfg.start_epoch, epochs):
 total_time = time.time() - start_time
 total_time_str = str(datetime.timedelta(seconds=int(total_time)))
 print(f'Training time {total_time_str}')
+train_dataset.close()
 
 # %%

--- a/proc/util/dataset.py
+++ b/proc/util/dataset.py
@@ -87,6 +87,21 @@ class MaskedSegyGather(Dataset):
 				)
 			)
 
+	def close(self) -> None:
+		"""Close all opened SEG-Y file objects."""
+		for info in self.file_infos:
+			segy_obj = info.get('segy_obj')
+			if segy_obj is not None:
+				try:
+					segy_obj.close()
+				except Exception:
+					pass
+		self.file_infos.clear()
+
+	def __del__(self) -> None:
+		self.close()
+
+
 	def _fit_time_len(self, x: np.ndarray, start: int | None = None) -> tuple[np.ndarray, int]:
 		T, target = x.shape[1], self.target_len
 		if start is None:


### PR DESCRIPTION
## Summary
- add `close` and `__del__` to `MaskedSegyGather` to close segyio file handles
- close datasets once validation items are prepared and after training completes

## Testing
- `ruff check proc/util/dataset.py proc/train.py` *(fails: Found 62 errors)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57aa124c0832b907a0136ca70fa9d