### PR TITLE
Add first-break segmentation task with Gaussian targets

### DIFF
--- a/proc/configs/train.yaml
+++ b/proc/configs/train.yaml
@@ -3,6 +3,8 @@ defaults:
   - base
   - _self_
 
+task: recon
+
 # 学習設定
 
 batch_size: 16
@@ -49,6 +51,7 @@ dataset:
   mask_ratio: 0.5
   mask_mode: add         # replace | add
   mask_noise_std: 3
+  label_sigma: 5.0
 
 # Loss configuration
 loss:

--- a/proc/util/collate.py
+++ b/proc/util/collate.py
@@ -12,17 +12,44 @@ def make_mask_2d(mask_indices_list, H, W, device):
 		mask[b, 0, idxs, :] = 1.0
 	return mask
 
-def segy_collate(batch):
-	"""Collate function for MaskedSegyGather outputs."""
+def segy_collate(batch, task: str = 'recon', label_sigma: float = 5.0):
+	"""Collate function for MaskedSegyGather outputs.
+
+	Parameters
+	----------
+	batch:
+	    Iterable of samples from :class:`MaskedSegyGather`.
+	task:
+	    ``'recon'`` for reconstruction (identity target) or ``'fb_seg'`` for
+	    first-break segmentation where a Gaussian target is generated.
+	label_sigma:
+	    Standard deviation of the Gaussian in samples. A lower bound of
+	    ``1e-6`` is enforced for numerical stability.
+
+	"""
 	x_masked = torch.stack([b['masked'] for b in batch], dim=0)
 	x_orig = torch.stack([b['original'] for b in batch], dim=0)
 	B, _, H, W = x_masked.shape
+
+	# create mask of randomly masked traces
 	mask_2d = torch.zeros((B, 1, H, W), dtype=x_masked.dtype)
 	for i, b in enumerate(batch):
 		idxs = b['mask_indices']
 		if idxs:
 			mask_2d[i, 0, idxs, :] = 1.0
+
 	fb_idx = torch.stack([b['fb_idx'] for b in batch], dim=0)
+
+	if task == 'fb_seg':
+		sigma = max(float(label_sigma), 1e-6)
+		t = torch.arange(W, dtype=x_masked.dtype).view(1, 1, 1, W)
+		t0 = fb_idx.to(x_masked.dtype).view(B, 1, H, 1)
+		gauss = torch.exp(-0.5 * ((t - t0) / sigma) ** 2)
+		valid = (fb_idx >= 0).view(B, 1, H, 1)
+		target = gauss * valid
+	else:
+		target = x_orig
+
 	meta = {
 		'file_path': [b['file_path'] for b in batch],
 		'key_name': [b['key_name'] for b in batch],
@@ -30,4 +57,4 @@ def segy_collate(batch):
 		'mask_indices': [b['mask_indices'] for b in batch],
 		'fb_idx': fb_idx,
 	}
-	return x_masked, x_orig, mask_2d, meta
+	return x_masked, target, mask_2d, meta

--- a/proc/util/train_loop.py
+++ b/proc/util/train_loop.py
@@ -28,7 +28,7 @@ def train_one_epoch(
 ):
 	"""Run one training epoch."""
 	model.train()
-	metric_logger = utils.MetricLogger(delimiter='  ')
+	metric_logger = utils.MetricLogger(delimiter='	')
 	metric_logger.add_meter('lr', utils.SmoothedValue(window_size=1, fmt='{value}'))
 	metric_logger.add_meter(
 		'samples/s', utils.SmoothedValue(window_size=10, fmt='{value:.3f}')
@@ -37,18 +37,24 @@ def train_one_epoch(
 	optimizer.zero_grad()
 	accum_loss = 0.0
 	for i, batch in enumerate(metric_logger.log_every(dataloader, print_freq, header)):
-		x_masked, x_orig, mask_2d, meta = batch
+		x_masked, target, mask_2d, meta = batch
 		start_time = time.time()
 		x_masked = x_masked.to(device, non_blocking=True)
-		x_orig = x_orig.to(device, non_blocking=True)
+		target = target.to(device, non_blocking=True)
 		mask_2d = mask_2d.to(device, non_blocking=True)
+		fb_idx = meta['fb_idx'].to(device, non_blocking=True)
 		device_type = (
 			'cuda' if torch.cuda.is_available() and 'cuda' in str(device) else 'cpu'
 		)
 		with autocast(device_type=device_type, enabled=use_amp):
 			pred = model(x_masked)
 			total_loss = criterion(
-				pred, x_orig, mask=mask_2d, max_shift=max_shift, reduction='mean'
+				pred,
+				target,
+				mask=mask_2d,
+				fb_idx=fb_idx,
+				max_shift=max_shift,
+				reduction='mean',
 			)
 			main_loss = total_loss / gradient_accumulation_steps
 		if scaler:


### PR DESCRIPTION
## Summary
- Support `fb_seg` task by generating Gaussian targets around first-break indices in the collate function
- Introduce dedicated MSE loss over valid traces and pluggable criterion based on task
- Update training loop, dataloaders, and config to switch between `recon` and `fb_seg`

## Testing
- `python -m py_compile proc/util/collate.py proc/util/loss.py proc/util/train_loop.py proc/train.py`
- `ruff check proc/util/collate.py proc/util/loss.py proc/util/train_loop.py proc/train.py` *(fails: indentation contains mixed spaces and tabs, naming, annotations)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c7ee8ae4832b98b059d19fdfcde0