### PR TITLE
Add first-break segmentation training mode

### DIFF
--- a/proc/configs/train.yaml
+++ b/proc/configs/train.yaml
@@ -5,6 +5,8 @@ defaults:
 
 # 学習設定
 
+task: recon
+
 batch_size: 16
 steps_per_epoch: 2000
 lr: 1e-5
@@ -49,6 +51,7 @@ dataset:
   mask_ratio: 0.5
   mask_mode: add         # replace | add
   mask_noise_std: 3
+  label_sigma: 5.0
 
 # Loss configuration
 loss:

--- a/proc/util/collate.py
+++ b/proc/util/collate.py
@@ -14,20 +14,24 @@ def make_mask_2d(mask_indices_list, H, W, device):
 
 def segy_collate(batch):
 	"""Collate function for MaskedSegyGather outputs."""
-	x_masked = torch.stack([b['masked'] for b in batch], dim=0)
-	x_orig = torch.stack([b['original'] for b in batch], dim=0)
-	B, _, H, W = x_masked.shape
-	mask_2d = torch.zeros((B, 1, H, W), dtype=x_masked.dtype)
-	for i, b in enumerate(batch):
-		idxs = b['mask_indices']
-		if idxs:
-			mask_2d[i, 0, idxs, :] = 1.0
-	fb_idx = torch.stack([b['fb_idx'] for b in batch], dim=0)
-	meta = {
-		'file_path': [b['file_path'] for b in batch],
-		'key_name': [b['key_name'] for b in batch],
-		'indices': [b['indices'] for b in batch],
-		'mask_indices': [b['mask_indices'] for b in batch],
-		'fb_idx': fb_idx,
-	}
-	return x_masked, x_orig, mask_2d, meta
+        x_masked = torch.stack([b['masked'] for b in batch], dim=0)
+        if 'target' in batch[0]:
+                x_tgt = torch.stack([b['target'] for b in batch], dim=0)
+                mask_2d = None
+        else:
+                x_tgt = torch.stack([b['original'] for b in batch], dim=0)
+                B, _, H, W = x_masked.shape
+                mask_2d = torch.zeros((B, 1, H, W), dtype=x_masked.dtype)
+                for i, b in enumerate(batch):
+                        idxs = b['mask_indices']
+                        if idxs:
+                                mask_2d[i, 0, idxs, :] = 1.0
+        fb_idx = torch.stack([b['fb_idx'] for b in batch], dim=0)
+        meta = {
+                'file_path': [b['file_path'] for b in batch],
+                'key_name': [b['key_name'] for b in batch],
+                'indices': [b['indices'] for b in batch],
+                'mask_indices': [b['mask_indices'] for b in batch],
+                'fb_idx': fb_idx,
+        }
+        return x_masked, x_tgt, mask_2d, meta

--- a/proc/util/dataset.py
+++ b/proc/util/dataset.py
@@ -8,10 +8,9 @@ import torch
 from torch.utils.data import Dataset
 
 from .augment import (
-	_apply_freq_augment,
-	_fit_time_len_np,
-	_spatial_stretch_sameH,
-	_time_stretch_poly,
+        _apply_freq_augment,
+        _spatial_stretch_sameH,
+        _time_stretch_poly,
 )
 
 __all__ = ['MaskedSegyGather']
@@ -40,9 +39,11 @@ class MaskedSegyGather(Dataset):
 		augment_freq_kinds: tuple[str, ...] = ('bandpass', 'lowpass', 'highpass'),
 		augment_freq_band: tuple[float, float] = (0.05, 0.45),
 		augment_freq_width: tuple[float, float] = (0.10, 0.35),
-		augment_freq_roll: float = 0.02,
-		augment_freq_restandardize: bool = True,
-	) -> None:
+                augment_freq_roll: float = 0.02,
+                augment_freq_restandardize: bool = True,
+                target_mode: Literal["recon", "fb_seg"] = "recon",
+                label_sigma: float = 5.0,
+        ) -> None:
 		"""Initialize dataset.
 
 		Args:
@@ -68,8 +69,10 @@ class MaskedSegyGather(Dataset):
 		self.augment_freq_kinds = augment_freq_kinds
 		self.augment_freq_band = augment_freq_band
 		self.augment_freq_width = augment_freq_width
-		self.augment_freq_roll = augment_freq_roll
-		self.augment_freq_restandardize = augment_freq_restandardize
+                self.augment_freq_roll = augment_freq_roll
+                self.augment_freq_restandardize = augment_freq_restandardize
+                self.target_mode = target_mode
+                self.label_sigma = float(label_sigma)
 		self.file_infos = []
 		for segy_path, fb_path in zip(self.segy_files, self.fb_files, strict=False):
 			print(f'Loading {segy_path} and {fb_path}')
@@ -169,16 +172,20 @@ class MaskedSegyGather(Dataset):
 		if self.flip and random.random() < 0.5:
 			x = np.flip(x, axis=0).copy()
 			fb_subset = fb_subset[::-1].copy()
-		if self.augment_time_prob > 0 and random.random() < self.augment_time_prob:
-			f_t = random.uniform(*self.augment_time_range)
-			x = _time_stretch_poly(x, f_t, target_len=self.target_len)
-		else:
-			x = _fit_time_len_np(x, self.target_len)
-		if self.augment_space_prob > 0 and random.random() < self.augment_space_prob:
-			f_h = random.uniform(*self.augment_space_range)
-			x = _spatial_stretch_sameH(x, f_h)
-		if self.augment_freq_prob > 0 and random.random() < self.augment_freq_prob:
-			x = _apply_freq_augment(
+                if self.augment_time_prob > 0 and random.random() < self.augment_time_prob:
+                        f_t = random.uniform(*self.augment_time_range)
+                        x, start = _time_stretch_poly(
+                                x, f_t, target_len=self.target_len, return_offset=True
+                        )
+                        fb_subset = fb_subset * f_t - start
+                else:
+                        x, start = self._fit_time_len(x)
+                        fb_subset = fb_subset - start
+                if self.augment_space_prob > 0 and random.random() < self.augment_space_prob:
+                        f_h = random.uniform(*self.augment_space_range)
+                        x = _spatial_stretch_sameH(x, f_h)
+                if self.augment_freq_prob > 0 and random.random() < self.augment_freq_prob:
+                        x = _apply_freq_augment(
 				x,
 				self.augment_freq_kinds,
 				self.augment_freq_band,
@@ -186,30 +193,48 @@ class MaskedSegyGather(Dataset):
 				self.augment_freq_roll,
 				self.augment_freq_restandardize,
 			)
-		H = x.shape[0]
-		num_mask = int(self.mask_ratio * H)
-		mask_idx = random.sample(range(H), num_mask) if num_mask > 0 else []
-		x_masked = x.copy()
-		if num_mask > 0:
-			noise = np.random.normal(0.0, self.mask_noise_std, size=(num_mask, x.shape[1]))
-			if self.mask_mode == "replace":
-				x_masked[mask_idx] = noise
-			elif self.mask_mode == "add":
-				x_masked[mask_idx] += noise
-			else:
-				raise ValueError(f'Invalid mask_mode: {self.mask_mode}')
-		fb_idx_win = fb_subset.astype(np.int64)
-		invalid = (fb_idx_win <= 0) | (fb_idx_win >= self.target_len)
-		fb_idx_win[invalid] = -1
-		x = torch.from_numpy(x)[None, ...]
-		xm = torch.from_numpy(x_masked)[None, ...]
-		fb_idx_t = torch.from_numpy(fb_idx_win)
-		return {
-			'masked': xm,
-			'original': x,
-			'mask_indices': mask_idx,
-			'fb_idx': fb_idx_t,
-			'key_name': key_name,
-			'indices': selected_indices,
-			'file_path': info['path'],
-		}
+                H = x.shape[0]
+                if self.target_mode == "recon":
+                        num_mask = int(self.mask_ratio * H)
+                        mask_idx = (
+                                random.sample(range(H), num_mask) if num_mask > 0 else []
+                        )
+                        x_masked = x.copy()
+                        if num_mask > 0:
+                                noise = np.random.normal(
+                                        0.0, self.mask_noise_std, size=(num_mask, x.shape[1])
+                                )
+                                if self.mask_mode == "replace":
+                                        x_masked[mask_idx] = noise
+                                elif self.mask_mode == "add":
+                                        x_masked[mask_idx] += noise
+                                else:
+                                        raise ValueError(f'Invalid mask_mode: {self.mask_mode}')
+                else:
+                        mask_idx = []
+                        x_masked = x.copy()
+
+                fb_idx_win = np.round(fb_subset).astype(np.int64)
+                invalid = (fb_idx_win <= 0) | (fb_idx_win >= self.target_len)
+                fb_idx_win[invalid] = -1
+                x_t = torch.from_numpy(x)[None, ...]
+                xm = torch.from_numpy(x_masked)[None, ...]
+                fb_idx_t = torch.from_numpy(fb_idx_win)
+                out = {
+                        'masked': xm,
+                        'original': x_t,
+                        'mask_indices': mask_idx,
+                        'fb_idx': fb_idx_t,
+                        'key_name': key_name,
+                        'indices': selected_indices,
+                        'file_path': info['path'],
+                }
+                if self.target_mode == "fb_seg":
+                        sigma = max(self.label_sigma, 1e-6)
+                        t = np.arange(self.target_len, dtype=np.float32)[None, :]
+                        g = np.exp(-0.5 * ((t - fb_idx_win[:, None]) / sigma) ** 2).astype(
+                                np.float32
+                        )
+                        g[fb_idx_win < 0] = 0.0
+                        out['target'] = torch.from_numpy(g)[None, ...]
+                return out


### PR DESCRIPTION
## Summary
- add `fb_seg` task support with Gaussian targets and new `label_sigma` parameter
- collate and training loop handle optional segmentation targets and `fb_idx`
- introduce `make_fb_seg_mse_criterion` for masked MSE over valid traces

## Testing
- ⚠️ `ruff check .` (fails: 609 errors)
- ⚠️ `pip install torch` (fails: Could not find a version that satisfies the requirement torch)

------
https://chatgpt.com/codex/tasks/task_e_68a79fac572c832bab99ad27225c5880