### PR TITLE
Enable task switching and guard recon-only evaluation

### DIFF
--- a/proc/configs/train.yaml
+++ b/proc/configs/train.yaml
@@ -3,6 +3,9 @@ defaults:
   - base
   - _self_
 
+# Training task
+task: recon  # or fb_seg
+
 # 学習設定
 
 batch_size: 16
@@ -49,8 +52,8 @@ dataset:
   mask_ratio: 0.5
   mask_mode: add         # replace | add
   mask_noise_std: 3
-  target_mode: recon
-  label_sigma: 1.0
+  target_mode: ${task}
+  label_sigma: 5.0
 
 # Loss configuration
 loss:


### PR DESCRIPTION
## Summary
- add `task` config with default `recon` and update dataset label_sigma
- skip SNR evaluation and synthetic visualization unless `task` is `recon`

## Testing
- `python -m py_compile proc/train.py`
- `ruff check proc/train.py` (fails: INP001, D100, PTH123, D101, ANN204, D107, ANN001, D105, ANN204, ANN001, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68a7bcd0bfd4832bad0d8268d23a25d7