### PR TITLE
Add offsets to segy collate meta

### DIFF
--- a/proc/util/collate.py
+++ b/proc/util/collate.py
@@ -24,11 +24,13 @@ def segy_collate(batch):
                 mask_indices_list = [b.get('mask_indices', []) for b in batch]
                 mask = make_mask_2d(mask_indices_list, H, W, device=x_masked.device)
         fb_idx = torch.stack([b['fb_idx'] for b in batch], dim=0)
+        offsets = torch.stack([b['offsets'] for b in batch], dim=0)
         meta = {
                 'file_path': [b['file_path'] for b in batch],
                 'key_name': [b['key_name'] for b in batch],
                 'indices': [b['indices'] for b in batch],
                 'mask_indices': [b.get('mask_indices', []) for b in batch],
                 'fb_idx': fb_idx,
+                'offsets': offsets,
         }
         return x_masked, teacher, mask, meta


### PR DESCRIPTION
## Summary
- Include stacked offsets tensor in `segy_collate` meta output alongside existing fields

## Testing
- `pytest -q`
- `ruff check proc/util/collate.py` *(fails: Missing docstring, type annotations, N806 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b69a0e3fc0832b8adc4c077deca29c