### PR TITLE
Forward offsets to loss function

### DIFF
--- a/proc/util/train_loop.py
+++ b/proc/util/train_loop.py
@@ -127,7 +127,7 @@ def train_one_epoch(
 		with autocast(device_type=device_type, enabled=use_amp):
 			pred = model(x_masked)
 			total_loss = criterion(
-				pred, x_tgt, mask=mask_or_none, fb_idx=meta['fb_idx']
+				pred, x_tgt, mask=mask_or_none, fb_idx=meta['fb_idx'], offsets=meta['offsets']
 			)
 			main_loss = total_loss / gradient_accumulation_steps
 		if scaler:


### PR DESCRIPTION
## Summary
- Pass `offsets` from batch metadata into the training criterion call to support offset-aware losses

## Testing
- `python -m py_compile proc/util/train_loop.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b5b8030832b84e692d25d88546f