### PR TITLE
config: add optional fb_seg smoothing params

### DIFF
--- a/proc/configs/base.yaml
+++ b/proc/configs/base.yaml
@@ -107,3 +107,6 @@ loss:
     type: kl   # "kl" or "mse"
     tau: 1.0   # softmax 温度
     eps: 0.02  # ラベルスムージング(0..0.05 程度)
+    smooth_lambda: 0.0      # 0 => disabled (backward compatible)
+    smooth_weight: inv      # inv | exp
+    smooth_scale: 1.0       # inv: denominator epsilon; exp: inverse temperature


### PR DESCRIPTION
## Summary
- add smooth_lambda, smooth_weight, and smooth_scale options under loss.fb_seg with defaults disabled

## Testing
- `pytest -q`
- `ruff check .` *(fails: Found 868 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b77fea0d48832b80a60684a08de5c5