### PR TITLE
Add curvature smoothness penalty for fb-seg KL loss

### DIFF
--- a/proc/configs/base.yaml
+++ b/proc/configs/base.yaml
@@ -107,3 +107,4 @@ loss:
     type: kl   # "kl" or "mse"
     tau: 1.0   # softmax 温度
     eps: 0.02  # ラベルスムージング(0..0.05 程度)
+    smooth2_lambda: 0.0   # curvature penalty weight; 0.0 keeps current behavior


### PR DESCRIPTION
## Summary
- add `smooth2_lambda` config option to weight curvature regularization
- extend KL fb-seg loss with optional first- and second-difference penalties and log components
- log curvature loss component during training

## Testing
- `ruff check proc/util/loss.py proc/util/train_loop.py` (fails: Found 124 errors)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7b78b4ecc832b93c6437808661eac