### PR TITLE
Add optional curvature penalty to FB segmentation loss

### DIFF
--- a/proc/configs/base.yaml
+++ b/proc/configs/base.yaml
@@ -110,3 +110,4 @@ loss:
     smooth_lambda: 0.05      # 0 => disabled (backward compatible)
     smooth_weight: inv      # inv | exp
     smooth_scale: 1.0       # inv: denominator epsilon; exp: inverse temperature
+    smooth2_lambda: 0.0   # curvature penalty weight; 0.0 keeps current behavior


### PR DESCRIPTION
## Summary
- allow configuration of curvature-based smoothness in fb segmentation loss via `smooth2_lambda`
- incorporate second-difference curvature penalty in KL loss and include term in total loss
- log curvature loss component during training

## Testing
- `ruff check proc/util/loss.py proc/util/train_loop.py` *(fails: SyntaxError: Expected a statement ... Found 106 errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7d7f611f8832b9de6ceeb19e66451