### PR TITLE
feat: add robust trend and Gaussian prior helpers

### DIFF
--- a/proc/util/loss.py
+++ b/proc/util/loss.py
@@ -1,9 +1,119 @@
 # %%
 # Fix: expand the leading K dimension before gather
 import time
+import math
 
 import torch
 import torch.nn.functional as F
+
+
+@torch.no_grad()
+def robust_linear_trend_sections(
+    offsets: torch.Tensor,   # (B,H) in meters
+    t_sec: torch.Tensor,     # (B,H) predicted time in seconds
+    valid: torch.Tensor,     # (B,H) boolean or 0/1; fb_idx>=0
+    section_len: int = 128,
+    stride: int = 64,
+    huber_c: float = 1.345,
+    iters: int = 3,
+    vmin: float = 300.0,
+    vmax: float = 6000.0,
+):
+    """Huber-IRLS linear fit per section: t(x) ≈ a + s*x.
+
+    Returns:
+      trend_t : (B,H) section-wise fitted times [s]
+      trend_s : (B,H) section-wise slowness [s/m]
+      v_trend : (B,H) section-wise velocity [m/s]
+
+    """
+    B, H = offsets.shape
+    x = offsets.to(t_sec)
+    y = t_sec
+    v = (valid > 0).to(t_sec)
+
+    trend_t = torch.zeros_like(y)
+    trend_s = torch.zeros_like(y)
+    counts  = torch.zeros_like(y)
+
+    eps = 1e-12
+    for start in range(0, H, stride):
+        end = min(H, start + section_len)
+        L = end - start
+        if L < 4:
+            continue
+
+        xs = x[:, start:end]   # (B,L)
+        ys = y[:, start:end]
+        vs = v[:, start:end]
+
+        # initialize with valid mask
+        w = vs.clone()
+
+        a = torch.zeros(B, 1, dtype=y.dtype, device=y.device)
+        b = torch.zeros(B, 1, dtype=y.dtype, device=y.device)  # slope (slowness)
+
+        for _ in range(iters):
+            Sw  = (w).sum(dim=1, keepdim=True).clamp_min(eps)
+            Sx  = (w * xs).sum(dim=1, keepdim=True)
+            Sy  = (w * ys).sum(dim=1, keepdim=True)
+            Sxx = (w * xs * xs).sum(dim=1, keepdim=True)
+            Sxy = (w * xs * ys).sum(dim=1, keepdim=True)
+
+            D   = (Sw * Sxx - Sx * Sx).clamp_min(eps)
+            b = (Sw * Sxy - Sx * Sy) / D
+            a = (Sy - b * Sx) / Sw
+
+            yhat = a + b * xs
+            res  = (ys - yhat) * vs  # invalid -> 0 residual
+
+            # robust scale (MAD)
+            # if all invalid, use tiny scale to keep weights ~0
+            abs_res = res.abs()
+            med = abs_res.median(dim=1, keepdim=True).values
+            scale = (1.4826 * med).clamp_min(1e-6)
+
+            r = res / (huber_c * scale)
+            # Huber IRLS weights
+            w = torch.where(r.abs() <= 1.0, vs, vs * (1.0 / r.abs()).clamp_max(10.0))
+
+        # clamp slowness by velocity bounds
+        s_sec = b.squeeze(1).clamp(min=1.0 / vmax, max=1.0 / vmin)  # (B,)
+        yhat  = (a + b * xs)
+
+        trend_t[:, start:end] += yhat
+        trend_s[:, start:end] += s_sec[:, None].expand(-1, L)
+        counts[:,  start:end] += vs.new_ones(B, L)
+
+    trend_t = trend_t / counts.clamp_min(1.0)
+    trend_s = trend_s / counts.clamp_min(1.0)
+    v_trend = (1.0 / trend_s.clamp_min(1e-6))
+    return trend_t, trend_s, v_trend
+
+
+def gaussian_prior_from_trend(
+    t_trend_sec: torch.Tensor,   # (B,H)
+    dt_sec: torch.Tensor,        # (B,1) or (B,)
+    W: int,
+    sigma_ms: float,
+    ref_tensor: torch.Tensor,
+):
+    """Make a per-trace Gaussian prior in time around t_trend.
+
+    Returns: prior probabilities of shape (B,H,W), each trace sums to 1.
+    """
+    B, H = t_trend_sec.shape
+    t = torch.arange(W, device=ref_tensor.device, dtype=ref_tensor.dtype).view(1,1,W)
+    if dt_sec.dim() == 1:
+        dt = dt_sec.view(B, 1, 1).to(ref_tensor)
+    else:
+        dt = dt_sec.to(ref_tensor).view(B, 1, 1)
+
+    mu = t_trend_sec.to(ref_tensor).unsqueeze(-1)  # (B,H,1)
+    sigma = max(sigma_ms * 1e-3, 1e-6)
+    logp = -0.5 * ((t*dt - mu) / sigma) ** 2       # (B,H,W)
+    prior = torch.softmax(logp, dim=-1)
+    return prior
 
 
 def shift_robust_l2_pertrace_vec(


### PR DESCRIPTION
## Summary
- add `robust_linear_trend_sections` for Huber IRLS per-section linear regression
- add `gaussian_prior_from_trend` to build Gaussian time priors around predicted trends

## Testing
- `ruff check proc/util/loss.py` *(fails: Found 102 errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba2ae3a534832bb977ee24c75805e1