### PR TITLE
Mask fb-seg logits with velocity feasibility cone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 *.png
 data/
 result/
+tmp_code/
 debug_*/
 # compiled コード
 *.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN addgroup --gid $GID $USERNAME && \
 USER $USERNAME
 
 COPY ruff.toml /home/$USERNAME
-ENV PYTHONPATH="${PYTHONPATH}:/workspace/proc/util"
+ENV PYTHONPATH="/workspace:${PYTHONPATH}"
 WORKDIR /workspace
 
 CMD ["/bin/bash"]

--- a/proc/configs/base.yaml
+++ b/proc/configs/base.yaml
@@ -9,7 +9,7 @@ valid_field_list: train_field_list_tstkres.txt
 file_size: null
 
 # パス関連
-suffix: 'edgenext_small.usi_in1k_in1k_finetune_augspace01_velmask'
+suffix: 'edgenext_small.usi_in1k_in1k_finetune_augspace01_modvelmask'
 
 # モデル関連（共通部分）
 backbone: edgenext_small.usi_in1k  # caformer_b36.sail_in22k_ft_in1k |edgenext_small.usi_in1k convnextv2_base.fcmae_ft_in22k_in1k_384
@@ -113,7 +113,11 @@ loss:
     smooth2_lambda: 0   # curvature penalty weight; 0.0 keeps current behavior
     use_vel_mask: true
     vmin_mask: 500.0     # m/s
-    vmax_mask: 6000.0    # m/s
-    t0_lo_ms: -20.0      # ms
+    vmax_mask: 6500.0    # m/s
+    t0_lo_ms: -50.0      # ms
     t0_hi_ms: 80.0       # ms
     taper_ms: 10.0       # ms
+
+debug:
+  audit_batches: 50          # 0 disables the audit
+  audit_cov_threshold: 0.5   # coverage threshold to flag low-coverage valid traces

--- a/proc/configs/train_field_list_wotstkres.txt
+++ b/proc/configs/train_field_list_wotstkres.txt
@@ -39,7 +39,6 @@ mooka2016
 noto21-2a
 noto21-2b
 noto21-3
-noto21-3a
 noto21-4
 noto21-5
 noto21-6

--- a/proc/debug/audit_fields.py
+++ b/proc/debug/audit_fields.py
@@ -1,0 +1,207 @@
+"""Debug script to audit offset fields using audit utilities."""
+
+# %%
+# /workspace/proc/debug/audit_fields.py
+"""Debug script to audit offset fields using audit utilities (no argparse)."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import torch
+from hydra import compose, initialize
+from torch.utils.data import DataLoader, SequentialSampler
+
+from proc.util.audit import audit_offsets_and_mask_coverage
+from proc.util.collate import segy_collate
+from proc.util.dataset import MaskedSegyGather
+from proc.util.rng_util import worker_init_fn
+from proc.util.velocity_mask import make_velocity_feasible_mask
+
+
+def _list_path(list_name: str) -> Path:
+	"""Find proc/configs/<list_name> first, then fallback to <repo_root>/configs."""
+	here = Path(__file__).resolve()
+	cand1 = here.parents[1] / 'configs' / list_name  # proc/configs/...
+	cand2 = here.parents[2] / 'configs' / list_name  # <repo>/configs/...
+	if cand1.exists():
+		return cand1
+	if cand2.exists():
+		return cand2
+	raise FileNotFoundError(
+		f'field list not found: {list_name} (looked in {cand1} and {cand2})'
+	)
+
+
+def _collect_field_files(list_name: str, data_root: str):
+	"""Return matching SEG-Y and FB files for each field listed."""
+	lp = _list_path(list_name)
+	with lp.open() as f:
+		fields = [
+			ln.strip() for ln in f if ln.strip() and not ln.strip().startswith('#')
+		]
+
+	segy_files, fb_files = [], []
+	for field in fields:
+		d = Path(data_root) / field
+		segys = sorted(list(d.glob('*.sgy')) + list(d.glob('*.segy')))
+		fbs = sorted(d.glob('*.npy'))
+		if not segys or not fbs:
+			print(f'[WARN] skip {field}: missing SEG-Y or FB')
+			continue
+		segy_files.append(segys[0])
+		fb_files.append(fbs[0])
+	return segy_files, fb_files
+
+
+def _audit_one_field(segy: Path, fb: Path, cfg, *, max_batches: int, cov_th: float):
+	"""Run audit for a single (segy, fb) pair and return stats dict."""
+	ds = MaskedSegyGather(
+		[segy],
+		[fb],
+		mask_ratio=0,
+		mask_mode=cfg.dataset.mask_mode,
+		mask_noise_std=0,
+		target_mode=cfg.dataset.target_mode,
+		label_sigma=cfg.dataset.label_sigma,
+		flip=False,
+		augment_time_prob=0.0,
+		augment_space_prob=0.0,
+		augment_freq_prob=0.0,
+	)
+	loader = DataLoader(
+		ds,
+		batch_size=cfg.batch_size,
+		sampler=SequentialSampler(ds),
+		shuffle=False,
+		num_workers=0,
+		pin_memory=True,
+		collate_fn=segy_collate,
+		drop_last=False,
+		worker_init_fn=worker_init_fn,
+	)
+
+	# 基本の監査（dx, coverage など）
+	stats = audit_offsets_and_mask_coverage(
+		loader, cfg.loss.fb_seg, max_batches=max_batches, cov_threshold=cov_th
+	)
+
+	# 追加: FB ラベルが velocity_mask 内/外にある割合
+	cnt_valid = 0
+	cnt_in = 0
+	cnt_out = 0
+	for i, (x, _, _, meta) in enumerate(loader):
+		if i >= max_batches:
+			break
+		fb_idx = meta['fb_idx']  # (B,H), -1=invalid
+		offsets = meta['offsets']  # (B,H)
+		dt_sec = meta['dt_sec']  # (B,) or (B,1)
+
+		B = fb_idx.size(0)
+		W = x.size(-1)  # time samples
+
+		# 可行速度コーン (B,H,W)
+		vm = make_velocity_feasible_mask(
+			offsets=offsets,
+			dt_sec=dt_sec,
+			W=W,
+			vmin=float(getattr(cfg.loss.fb_seg, 'vmin_mask', 500.0)),
+			vmax=float(getattr(cfg.loss.fb_seg, 'vmax_mask', 6000.0)),
+			t0_lo_ms=float(getattr(cfg.loss.fb_seg, 't0_lo_ms', -20.0)),
+			t0_hi_ms=float(getattr(cfg.loss.fb_seg, 't0_hi_ms', 80.0)),
+			taper_ms=float(getattr(cfg.loss.fb_seg, 'taper_ms', 10.0)),
+			device=offsets.device,
+			dtype=torch.float32,
+		)
+
+		valid = fb_idx >= 0
+		if valid.any():
+			# ラベル位置でのマスク値を抽出
+			idx = fb_idx.clamp_min(0).unsqueeze(
+				-1
+			)  # (B,H,1), invalidは0参照だが後で除外
+			m_at = vm.gather(-1, idx).squeeze(-1)  # (B,H) at label time
+			m_at = m_at[valid]  # valid only
+
+			cnt_valid += int(valid.sum())
+			cnt_in += int((m_at > 0).sum())
+			cnt_out += int((m_at <= 0).sum())
+
+	stats['rate_fb_in'] = cnt_in / max(cnt_valid, 1)
+	stats['rate_fb_out'] = cnt_out / max(cnt_valid, 1)
+	print('dt_sec:', dt_sec)
+	print('offsets:', offsets)
+	if hasattr(ds, 'close'):
+		ds.close()
+	return stats
+
+
+def _audit_for_list(cfg, list_key: str, out_csv: Path | None):
+	"""Audit all fields in cfg.<list_key> and optionally write CSV."""
+	if not hasattr(cfg, list_key):
+		print(f"[INFO] cfg has no '{list_key}', skip.")
+		return []
+
+	list_name = getattr(cfg, list_key)
+	data_root = Path(cfg.data_root)
+	if not data_root.exists():
+		print(f'[WARN] data_root not found: {data_root} — skip {list_key}')
+		return []
+
+	segy_files, fb_files = _collect_field_files(list_name, str(data_root))
+	if not segy_files:
+		print(f'[WARN] no files for {list_key}={list_name}')
+		return []
+
+	# debug knobs from cfg.debug (with fallbacks)
+	audit_batches = int(getattr(getattr(cfg, 'debug', object()), 'audit_batches', 30))
+	cov_th = float(getattr(getattr(cfg, 'debug', object()), 'audit_cov_threshold', 0.5))
+
+	rows = []
+	for segy, fb in zip(segy_files, fb_files, strict=False):
+		field = Path(segy).parent.name
+		print(f'\n===== [AUDIT FIELD] {field} ({list_key}) =====')
+		print(f'  segy: {segy}')
+		print(f'  fb  : {fb}')
+		stats = _audit_one_field(
+			segy, fb, cfg, max_batches=audit_batches, cov_th=cov_th
+		)
+		# 簡単な表示を追加
+		if 'rate_fb_in' in stats and 'rate_fb_out' in stats:
+			print(f'  rate_fb_in:  {stats["rate_fb_in"]:.3f}')
+			print(f'  rate_fb_out: {stats["rate_fb_out"]:.3f}')
+		row = {'field': field, 'list_key': list_key}
+		row.update(stats)
+		rows.append(row)
+
+	if out_csv and rows:
+		out_csv.parent.mkdir(parents=True, exist_ok=True)
+		keys = list(rows[0].keys())
+		with out_csv.open('w', newline='') as f:
+			w = csv.DictWriter(f, fieldnames=keys)
+			w.writeheader()
+			for r in rows:
+				w.writerow(r)
+		print(f'[SUMMARY] wrote {out_csv.resolve()}')
+
+	return rows
+
+
+def main():
+	# hydra config: use relative path from this script → proc/configs
+	with initialize(config_path='../configs', version_base='1.3'):
+		cfg = compose(config_name='base')
+
+	out_dir = Path('result/audit')
+	train_csv = out_dir / 'train_fields.csv'
+	valid_csv = out_dir / 'valid_fields.csv'
+
+	_audit_for_list(cfg, 'train_field_list', train_csv)
+	_audit_for_list(cfg, 'valid_field_list', valid_csv)
+
+	print('\n[SUMMARY] per-field audits finished.')
+
+
+if __name__ == '__main__':
+	main()

--- a/proc/debug/vis_fb_mask.py
+++ b/proc/debug/vis_fb_mask.py
@@ -1,0 +1,313 @@
+# %%
+# %%
+# /workspace/proc/debug/vis_fb_mask.py
+# %%
+# /workspace/proc/debug/vis_fb_mask_multi.py
+"""Visualize amplitude + velocity_mask + FB labels
+for multiple shots from one field (no section slicing).
+
+- Loads cfg from proc/configs/base.yaml (no argparse)
+- Picks one field (by index) from cfg.<which_list>
+- Iterates several shots (batch_size=1), computes velocity_mask per shot
+- Saves PNGs under result/vis_fb_mask/<field>/shot<k>/
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from hydra import compose, initialize
+from torch.utils.data import DataLoader, SequentialSampler
+
+from proc.util.collate import segy_collate
+from proc.util.dataset import MaskedSegyGather
+from proc.util.rng_util import worker_init_fn
+from proc.util.velocity_mask import make_velocity_feasible_mask
+
+# ===== user knobs =====
+which_list = 'train_field_list'  # 'train_field_list' or 'valid_field_list'
+field_index = 4  # どのフィールドを可視化するか（0始まり）
+max_shots_per_field = 8  # 何ショット表示するか（None で全ショット）
+shot_stride = 1  # 例: 2 にすると 1本おきに拾う
+n_traces_detail = 8  # 個別表示するトレース本数
+# ======================
+
+
+def _list_path(list_name: str) -> Path:
+	here = Path(__file__).resolve()
+	cand1 = here.parents[1] / 'configs' / list_name
+	cand2 = here.parents[2] / 'configs' / list_name
+	if cand1.exists():
+		return cand1
+	if cand2.exists():
+		return cand2
+	raise FileNotFoundError(
+		f'field list not found: {list_name} (looked in {cand1}, {cand2})'
+	)
+
+
+def _collect_field_files(list_name: str, data_root: Path):
+	lp = _list_path(list_name)
+	with lp.open() as f:
+		fields = [
+			ln.strip() for ln in f if ln.strip() and not ln.strip().startswith('#')
+		]
+	segy_files, fb_files = [], []
+	for field in fields:
+		d = data_root / field
+		segys = sorted(list(d.glob('*.sgy')) + list(d.glob('*.segy')))
+		fbs = sorted(d.glob('*.npy'))
+		if not segys or not fbs:
+			print(f'[WARN] skip {field}: missing SEG-Y or FB')
+			continue
+		segy_files.append(segys[0])
+		fb_files.append(fbs[0])
+	return fields, segy_files, fb_files
+
+
+@torch.no_grad()
+def _shot_vm_and_stats(x, meta, cfg_fb):
+	"""Compute velmask for the whole shot and quick stats.
+	Returns: vm (1,H,W) float32, stats dict
+	"""
+	fb_idx = meta['fb_idx']  # (1,H)
+	offsets = meta['offsets']  # (1,H)
+	dt_sec = meta['dt_sec']  # (1,) or (1,1)
+	_, _, H, W = x.shape
+
+	vm = make_velocity_feasible_mask(
+		offsets=offsets,
+		dt_sec=dt_sec,
+		W=W,
+		vmin=float(getattr(cfg_fb, 'vmin_mask', 500.0)),
+		vmax=float(getattr(cfg_fb, 'vmax_mask', 10000.0)),
+		t0_lo_ms=float(getattr(cfg_fb, 't0_lo_ms', -100.0)),
+		t0_hi_ms=float(getattr(cfg_fb, 't0_hi_ms', 80.0)),
+		taper_ms=float(getattr(cfg_fb, 'taper_ms', 10.0)),
+		device=offsets.device,
+		dtype=torch.float32,
+	)  # (1,H,W)
+
+	coverage = (vm > 0).float().mean(dim=-1)  # (1,H)
+	valid = fb_idx >= 0
+	rate_fb_in = 0.0
+	rate_fb_out = 0.0
+	if valid.any():
+		idx = fb_idx.clamp_min(0).unsqueeze(-1)  # (1,H,1)
+		m_at = vm.gather(-1, idx).squeeze(-1)  # (1,H)
+		m_at = m_at[valid]
+		rate_fb_in = float((m_at > 0).float().mean().item())
+		rate_fb_out = 1.0 - rate_fb_in
+
+	stats = {
+		'coverage_med': float(coverage.median().item()),
+		'coverage_p05': float(torch.quantile(coverage.flatten(), 0.05).item()),
+		'coverage_p95': float(torch.quantile(coverage.flatten(), 0.95).item()),
+		'rate_fb_in': rate_fb_in,
+		'rate_fb_out': rate_fb_out,
+	}
+	return vm, stats
+
+
+def _panel_plot(x, vm, fb_idx, dt_sec, outpng: Path, title: str):
+	"""Whole-shot panel: x(1,1,H,W), vm(1,H,W), fb_idx(1,H)"""
+	x = x[0, 0].cpu().numpy()
+	vm = vm[0].cpu().numpy()
+	fb = fb_idx[0].cpu().numpy()
+	H, W = x.shape
+	dt = float(dt_sec.view(-1)[0].item())
+	t_axis = np.arange(W) * dt
+
+	v = np.abs(x)
+	vmax = np.quantile(v, 0.995) + 1e-12
+	vmin = -vmax
+
+	fig, ax = plt.subplots(figsize=(12, 5.5))
+	extent = [t_axis[0], t_axis[-1], 0, H]
+	im = ax.imshow(
+		x,
+		cmap='gray',
+		vmin=vmin,
+		vmax=vmax,
+		extent=extent,
+		aspect='auto',
+		origin='lower',
+		interpolation='nearest',
+	)
+	ax.imshow(
+		vm,
+		cmap='Reds',
+		alpha=0.25,
+		extent=extent,
+		aspect='auto',
+		origin='lower',
+		interpolation='nearest',
+	)
+
+	valid = fb >= 0
+	if valid.any():
+		t_fb = fb[valid] * dt
+		h_idx = np.nonzero(valid)[0]
+		ax.scatter(
+			t_fb, h_idx, s=5, c='cyan', marker='o', linewidths=0.0, label='FB label'
+		)
+
+	ax.set_xlabel('Time [s]')
+	ax.set_ylabel('Trace index')
+	ax.set_title(title)
+	if valid.any():
+		ax.legend(loc='upper right', fontsize=9)
+	cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.02)
+	cbar.set_label('Amplitude')
+	fig.tight_layout()
+	fig.savefig(outpng, dpi=150)
+	plt.close(fig)
+	print(f'[SAVE] {outpng}')
+
+
+def _trace_detail_plot(x, vm, fb_idx, dt_sec, outpng: Path, k: int):
+	"""Pick several traces across H and plot waveforms + mask + FB."""
+	x = x[0, 0].cpu().numpy()  # (H,W)
+	vm = vm[0].cpu().numpy()  # (H,W)
+	fb = fb_idx[0].cpu().numpy()  # (H,)
+	H, W = x.shape
+	dt = float(dt_sec.view(-1)[0].item())
+	t_axis = np.arange(W) * dt
+
+	if k >= H:
+		traces = np.arange(H)
+	else:
+		traces = np.linspace(0, H - 1, k).round().astype(int)
+
+	fig_h = 2.2 * len(traces)
+	fig, axes = plt.subplots(len(traces), 1, figsize=(10, fig_h), sharex=True)
+	if len(traces) == 1:
+		axes = [axes]
+
+	for ax, h in zip(axes, traces, strict=False):
+		sig = x[h]
+		sig = sig / (np.std(sig) + 1e-12)
+		ax.plot(t_axis, sig, lw=0.7, label=f'trace {h} (norm amp)')
+		m = vm[h] > 0
+		if m.any():
+			ax.fill_between(
+				t_axis, -1.2, 1.2, where=m, alpha=0.12, step='pre', label='mask>0'
+			)
+		if fb[h] >= 0:
+			ax.axvline(fb[h] * dt, color='r', ls='--', lw=1.0, label='FB')
+		ax.set_ylim(-1.2, 1.2)
+		ax.set_ylabel('amp (norm)')
+		ax.grid(True, alpha=0.3)
+		ax.legend(loc='upper right', fontsize=8)
+
+	axes[-1].set_xlabel('Time [s]')
+	fig.tight_layout()
+	fig.savefig(outpng, dpi=150)
+	plt.close(fig)
+	print(f'[SAVE] {outpng}')
+
+
+def main():
+	# load cfg
+	with initialize(config_path='../configs', version_base='1.3'):
+		cfg = compose(config_name='base')
+
+	data_root = Path(cfg.data_root)
+	fields, segys, fbs = _collect_field_files(getattr(cfg, which_list), data_root)
+	if not segys:
+		print(f'[WARN] no files for list={which_list}')
+		return
+
+	# choose one field
+	idx = max(0, min(field_index, len(segys) - 1))
+	field = fields[idx]
+	segy = segys[idx]
+	fb = fbs[idx]
+
+	print(f'\n===== [VIS FIELD] {field} ({which_list}) =====')
+	print(f'  segy: {segy}')
+	print(f'  fb  : {fb}')
+
+	out_root = Path('result/vis_fb_mask') / field
+	out_root.mkdir(parents=True, exist_ok=True)
+
+	ds = MaskedSegyGather(
+		[segy],
+		[fb],
+		mask_ratio=0,
+		mask_mode=cfg.dataset.mask_mode,
+		mask_noise_std=0,
+		target_mode=cfg.dataset.target_mode,
+		label_sigma=cfg.dataset.label_sigma,
+		flip=False,
+		augment_time_prob=0.0,
+		augment_space_prob=0.0,
+		augment_freq_prob=0.0,
+	)
+	loader = DataLoader(
+		ds,
+		batch_size=1,
+		sampler=SequentialSampler(ds),
+		shuffle=False,
+		num_workers=0,
+		pin_memory=True,
+		collate_fn=segy_collate,
+		drop_last=False,
+		worker_init_fn=worker_init_fn,
+	)
+
+	shot_count = 0
+	for i, (x, _, _, meta) in enumerate(loader):
+		if (i % max(1, shot_stride)) != 0:
+			continue
+		if (
+			isinstance(max_shots_per_field, int)
+			and max_shots_per_field > 0
+			and shot_count >= max_shots_per_field
+		):
+			break
+
+		vm, stats = _shot_vm_and_stats(x, meta, cfg.loss.fb_seg)
+		B, C, H, W = x.shape
+		print(
+			f'[SHOT {i:04d}] H={H} W={W}  '
+			f'coverage med/p05/p95: {stats["coverage_med"]:.3f}/'
+			f'{stats["coverage_p05"]:.3f}/{stats["coverage_p95"]:.3f}  '
+			f'rate_fb_in/out: {stats["rate_fb_in"]:.3f}/{stats["rate_fb_out"]:.3f}'
+		)
+
+		shot_dir = out_root / f'shot{i:04d}'
+		shot_dir.mkdir(parents=True, exist_ok=True)
+
+		_panel_plot(
+			x,
+			vm,
+			meta['fb_idx'],
+			meta['dt_sec'],
+			shot_dir / f'shot{i:04d}_panel.png',
+			title=f'{field}  shot {i}',
+		)
+		_trace_detail_plot(
+			x,
+			vm,
+			meta['fb_idx'],
+			meta['dt_sec'],
+			shot_dir / f'shot{i:04d}_traces.png',
+			k=n_traces_detail,
+		)
+
+		shot_count += 1
+
+	if hasattr(ds, 'close'):
+		ds.close()
+	print(f'\n[DONE] saved {shot_count} shots under: {out_root.resolve()}')
+
+
+if __name__ == '__main__':
+	main()
+
+
+# %%

--- a/proc/fb2fbnpy.py
+++ b/proc/fb2fbnpy.py
@@ -72,7 +72,7 @@ for field_dir in field_dir_list:
 		print('Error: No or multiple files found in', field_dir)
 		continue
 	with segyio.open(segy_file[0], 'r', ignore_geometry=True) as f:
-		dt = f.bin[segyio.BinField.Interval] / 1e4
+		dt = f.bin[segyio.BinField.Interval] / 1e3
 		nt = f.samples.size
 	maxnt = max(maxnt, nt)
 	print(dt, nt)

--- a/proc/util/__init__.py
+++ b/proc/util/__init__.py
@@ -1,36 +1,15 @@
-from .augment import (
-	_apply_freq_augment,
-	_cosine_ramp,
-	_fit_time_len_np,
-	_make_freq_mask,
-	_spatial_stretch_sameH,
-	_time_stretch_poly,
-)
-from .collate import make_mask_2d, segy_collate
-from .data_io import _read_gather_by_indices, load_synth_pair
+from .collate import segy_collate
 from .dataset import MaskedSegyGather
-from .eval import eval_synthe, val_one_epoch_snr
 from .predict import cover_all_traces_predict, cover_all_traces_predict_chunked
 from .rng_util import worker_init_fn
-from .train_loop import criterion, train_one_epoch
+
+# from .train_loop import train_one_epoch  # Uncomment if needed
 
 __all__ = [
-	'MaskedSegyGather',
-	'_apply_freq_augment',
-	'_cosine_ramp',
-	'_fit_time_len_np',
-	'_make_freq_mask',
-	'_read_gather_by_indices',
-	'_spatial_stretch_sameH',
-	'_time_stretch_poly',
-	'cover_all_traces_predict',
-	'cover_all_traces_predict_chunked',
-	'criterion',
-	'eval_synthe',
-	'load_synth_pair',
-	'make_mask_2d',
-	'segy_collate',
-	'train_one_epoch',
-	'val_one_epoch_snr',
-	'worker_init_fn',
+    'MaskedSegyGather',
+    'cover_all_traces_predict',
+    'cover_all_traces_predict_chunked',
+    'segy_collate',
+    'worker_init_fn',
+    # 'train_one_epoch',
 ]

--- a/proc/util/audit.py
+++ b/proc/util/audit.py
@@ -1,0 +1,138 @@
+# proc/util/audit.py
+"""Audit utilities for velocity mask and offset sanity checks."""
+
+import math
+from typing import Any
+
+import torch
+
+from proc.util.velocity_mask import make_velocity_feasible_mask
+
+
+@torch.no_grad()
+def assert_meta_shapes(meta: dict, B: int, H: int) -> None:
+    """Lightweight shape/finite checks for meta fields used by velocity mask."""
+    offs = meta['offsets']
+    dt = meta['dt_sec']
+    assert offs.ndim == 2 and offs.shape == (B, H), f"offsets shape {offs.shape}, expected {(B, H)}"
+    assert torch.isfinite(offs).all(), "offsets has NaN/Inf"
+    assert dt.ndim in (1, 2) and dt.shape[0] == B, f"dt_sec shape {dt.shape}, expected (B,) or (B,1)"
+    assert torch.isfinite(dt).all(), "dt_sec has NaN/Inf"
+
+@torch.no_grad()
+def audit_offsets_and_mask_coverage(
+    loader,
+    cfg_fb,
+    max_batches: int = 100,
+    cov_threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Scan a few batches and report:
+    - dx stats (min/median/max), count of dx==0
+    - traces where velocity mask is all-zero
+    - fraction of target probability mass that lies inside the velocity cone
+    - crude checks for offsets sanity
+    """
+    dx0_total = 0
+    zero_mask_tr = 0
+    low_cov_tr = 0
+    total_tr = 0
+
+    nan_off_elems = 0
+    nan_dt_elems = 0
+    all_equal_shot = 0  # offsets constant over H (likely unset)
+    nonmonotonic_shot = 0
+
+    dx_min = float("inf")
+    dx_max = 0.0
+    dx_meds = []
+
+    for bi, (x, target, _, meta) in enumerate(loader):
+        B, _, H, W = x.shape
+        offs = meta['offsets']
+        dt = meta['dt_sec']
+        fb_idx = meta['fb_idx']
+        total_tr += B * H
+
+        # Shapes & finite checks
+        try:
+            assert_meta_shapes(meta, B, H)
+        except AssertionError as e:
+            print(f"[AUDIT][batch {bi}] SHAPE/FIN ERROR: {e}")
+            # continue; still try to collect more info
+
+        # NaN/Inf counters (element-wise)
+        nan_off_elems += int((~torch.isfinite(offs)).sum().item())
+        nan_dt_elems  += int((~torch.isfinite(dt)).sum().item())
+
+        # Per-shot "all offsets equal?" and monotonicity probes
+        # all_equal over H (no variation → likely missing offsets)
+        diffs = (offs[:, 1:] - offs[:, :-1])
+        all_equal_shot += int((diffs.abs().sum(dim=1) == 0).sum().item())
+        nonmonotonic_shot += int(((diffs >= 0).all(dim=1) | (diffs <= 0).all(dim=1)).logical_not().sum().item())
+
+        # dx stats over H
+        dx = diffs.abs()
+        dx0_total += int((dx == 0).sum().item())
+        if dx.numel() > 0:
+            dx_min = min(dx_min, float(dx.min().cpu()))
+            dx_max = max(dx_max, float(dx.max().cpu()))
+            dx_meds.append(float(dx.median().cpu()))
+
+        # Velocity-cone mask
+        velmask = make_velocity_feasible_mask(
+            offsets=offs,
+            dt_sec=dt,
+            W=W,
+            vmin=float(getattr(cfg_fb, 'vmin_mask', 500.0)),
+            vmax=float(getattr(cfg_fb, 'vmax_mask', 6000.0)),
+            t0_lo_ms=float(getattr(cfg_fb, 't0_lo_ms', -20.0)),
+            t0_hi_ms=float(getattr(cfg_fb, 't0_hi_ms', 80.0)),
+            taper_ms=float(getattr(cfg_fb, 'taper_ms', 10.0)),
+            device=offs.device,
+            dtype=offs.dtype,
+        )
+
+        # Detect traces whose mask is entirely zero
+        zero_mask = (velmask.sum(dim=-1) == 0)  # (B,H)
+        zero_mask_tr += int(zero_mask.sum().item())
+
+        # Target coverage inside the cone (per trace)
+        q = target.squeeze(1).to(velmask)                  # (B,H,W)
+        q = q / q.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+        cov = (q * velmask).sum(dim=-1)                    # (B,H) in [0,1]
+
+        valid = (fb_idx >= 0)
+        low_cov = (cov < cov_threshold) & valid
+        low_cov_tr += int(low_cov.sum().item())
+
+        if (bi + 1) >= max_batches:
+            break
+
+    dx_med = float(torch.tensor(dx_meds).median().item()) if dx_meds else float("nan")
+
+    stats = {
+        "traces": int(total_tr),
+        "dx_min": dx_min if math.isfinite(dx_min) else float("nan"),
+        "dx_med": dx_med,
+        "dx_max": dx_max if math.isfinite(dx_max) else float("nan"),
+        "dx_eq0": int(dx0_total),
+        "mask_all_zero_traces": int(zero_mask_tr),
+        "low_coverage_traces": int(low_cov_tr),
+        "nan_off_elems": int(nan_off_elems),
+        "nan_dt_elems": int(nan_dt_elems),
+        "all_equal_shots": int(all_equal_shot),
+        "nonmonotonic_shots": int(nonmonotonic_shot),
+        "cov_threshold": float(cov_threshold),
+    }
+
+    # Pretty print summary
+    print("[AUDIT] traces:            ", stats["traces"])
+    print(f"[AUDIT] dx[m] min/med/max: {stats['dx_min']:.6g} / {stats['dx_med']:.6g} / {stats['dx_max']:.6g}")
+    print( "[AUDIT] dx==0 count:       ", stats["dx_eq0"])
+    print( "[AUDIT] mask==0 traces:    ", stats["mask_all_zero_traces"])
+    print( "[AUDIT] low coverage (<{:.2f}) valid traces: {}".format(stats["cov_threshold"], stats["low_coverage_traces"]))
+    print( "[AUDIT] NaN/Inf offsets elts:", stats["nan_off_elems"], "  NaN/Inf dt_sec elts:", stats["nan_dt_elems"])
+    print( "[AUDIT] shots all-equal offsets:", stats["all_equal_shots"],
+           "  non-monotonic shots (mixed up/down):", stats["nonmonotonic_shots"])
+
+    return stats

--- a/proc/util/eval.py
+++ b/proc/util/eval.py
@@ -1,8 +1,9 @@
 import numpy as np
 import torch
 import torch.nn.functional as F
-from metrics import prepare_fb_windows, snr_improvement_from_cached_windows
-from vis import visualize_recon_triplet
+
+from proc.util.metrics import prepare_fb_windows, snr_improvement_from_cached_windows
+from proc.util.vis import visualize_recon_triplet
 
 from .predict import cover_all_traces_predict
 

--- a/proc/util/loss.py
+++ b/proc/util/loss.py
@@ -5,7 +5,7 @@ import time
 import torch
 import torch.nn.functional as F
 
-from util.velocity_mask import make_velocity_feasible_mask
+from proc.util.velocity_mask import make_velocity_feasible_mask
 
 
 def shift_robust_l2_pertrace_vec(

--- a/proc/util/velocity_mask.py
+++ b/proc/util/velocity_mask.py
@@ -6,61 +6,61 @@ import torch
 
 @torch.no_grad()
 def make_velocity_feasible_mask(
-    offsets: torch.Tensor,   # (B,H) [m]
-    dt_sec: torch.Tensor,    # (B,) or (B,1) [s]
-    W: int,                  # time bins (width)
-    vmin: float,             # [m/s] slowest plausible (largest t)
-    vmax: float,             # [m/s] fastest plausible (smallest t)
-    t0_lo_ms: float = -20.0, # early slack (can be negative)
-    t0_hi_ms: float = 80.0,  # late slack
-    taper_ms: float = 10.0,  # Hann taper half-width at both boundaries
-    device=None,
-    dtype=None,
+	offsets: torch.Tensor,  # (B,H) [m]
+	dt_sec: torch.Tensor,  # (B,) or (B,1) [s]
+	W: int,  # time bins (width)
+	vmin: float,  # [m/s] slowest plausible (largest t)
+	vmax: float,  # [m/s] fastest plausible (smallest t)
+	t0_lo_ms: float = -20.0,  # early slack (can be negative)
+	t0_hi_ms: float = 80.0,  # late slack
+	taper_ms: float = 10.0,  # Hann taper half-width at both boundaries
+	device=None,
+	dtype=None,
 ) -> torch.Tensor:
-    """Return mask (B,H,W) in [0,1]: inside the velocity cone ~1, outside ~0,
-    with optional Hann taper at the boundaries for smoothness.
-    """
-    device = device or offsets.device
-    dtype  = dtype  or offsets.dtype
-    B, H = offsets.shape
+	"""Return mask (B,H,W) in [0,1]: inside the velocity cone ~1, outside ~0,
+	with optional Hann taper at the boundaries for smoothness.
+	"""
+	device = device or offsets.device
+	dtype = dtype or offsets.dtype
+	B, H = offsets.shape
 
-    dt = dt_sec.to(device=device, dtype=dtype).view(B, 1, 1)   # (B,1,1)
-    x  = offsets.to(device=device, dtype=dtype).view(B, H, 1)  # (B,H,1)
-    t  = torch.arange(W, device=device, dtype=dtype).view(1, 1, W) * dt  # (B,1,W)
+	dt = dt_sec.to(device=device, dtype=dtype).view(B, 1, 1)  # (B,1,1)
+	x = offsets.to(device=device, dtype=dtype).view(B, H, 1).abs()  # (B,H,1)
 
-    # Cone bounds in seconds (with slack)
-    t_min = (x / max(vmax, 1e-6)) + (t0_lo_ms * 1e-3)
-    t_max = (x / max(vmin, 1e-6)) + (t0_hi_ms * 1e-3)
-    t_min = t_min.clamp_min(0.0)
+	t = torch.arange(W, device=device, dtype=dtype).view(1, 1, W) * dt  # (B,1,W)
 
-    inside = (t >= t_min) & (t <= t_max)
-    mask = inside.to(dtype)
+	# Cone bounds in seconds (with slack)
+	t_min = (x / max(vmax, 1e-6)) + (t0_lo_ms * 1e-3)
+	t_max = (x / max(vmin, 1e-6)) + (t0_hi_ms * 1e-3)
+	t_min = t_min.clamp_min(0.0)
 
-    if taper_ms > 0:
-        w = max(taper_ms * 1e-3, 1e-6)
+	inside = (t >= t_min) & (t <= t_max)
+	mask = inside.to(dtype)
 
-        # lower transition: [t_min - w, t_min] : 0 -> 1
-        lower = (t >= (t_min - w)) & (t < t_min)
-        r_lo = ((t - (t_min - w)) / w).clamp(0.0, 1.0)
-        hann_lo = 0.5 * (1.0 - torch.cos(math.pi * r_lo))
-        mask = torch.where(lower, hann_lo.to(dtype), mask)
+	if taper_ms > 0:
+		w = max(taper_ms * 1e-3, 1e-6)
 
-        # upper transition: [t_max, t_max + w] : 1 -> 0
-        upper = (t > t_max) & (t <= (t_max + w))
-        r_up = ((t_max + w - t) / w).clamp(0.0, 1.0)
-        hann_up = 0.5 * (1.0 - torch.cos(math.pi * r_up))
-        mask = torch.where(upper, hann_up.to(dtype), mask)
+		# lower transition: [t_min - w, t_min] : 0 -> 1
+		lower = (t >= (t_min - w)) & (t < t_min)
+		r_lo = ((t - (t_min - w)) / w).clamp(0.0, 1.0)
+		hann_lo = 0.5 * (1.0 - torch.cos(math.pi * r_lo))
+		mask = torch.where(lower, hann_lo.to(dtype), mask)
 
-    return mask  # (B,H,W)
+		# upper transition: [t_max, t_max + w] : 1 -> 0
+		upper = (t > t_max) & (t <= (t_max + w))
+		r_up = ((t_max + w - t) / w).clamp(0.0, 1.0)
+		hann_up = 0.5 * (1.0 - torch.cos(math.pi * r_up))
+		mask = torch.where(upper, hann_up.to(dtype), mask)
+
+	return mask  # (B,H,W)
 
 
 def apply_velocity_mask_to_logits(
-    logits: torch.Tensor,   # (B,1,H,W)
-    mask: torch.Tensor,     # (B,H,W)
-    eps: float = 1e-12,
+	logits: torch.Tensor,  # (B,1,H,W)
+	mask: torch.Tensor,  # (B,H,W)
+	eps: float = 1e-12,
 ) -> torch.Tensor:
-    """Add log(mask) to logits so that outside the cone becomes ~ -inf (prob ~ 0).
-    """
-    assert logits.dim() == 4 and logits.size(1) == 1
-    logits[:, 0] = logits[:, 0] + torch.log(mask.clamp_min(eps))
-    return logits
+	"""Add log(mask) to logits so that outside the cone becomes ~ -inf (prob ~ 0)."""
+	assert logits.dim() == 4 and logits.size(1) == 1
+	logits[:, 0] = logits[:, 0] + torch.log(mask.clamp_min(eps))
+	return logits


### PR DESCRIPTION
## Summary
- integrate velocity feasibility mask into KL-based first-break segmentation loss
- track fraction of logits retained via `vel_keep` in loss stats
- add configurable toggles for velocity mask parameters (`use_vel_mask`, `vmin_mask`, `vmax_mask`, `t0_lo_ms`, `t0_hi_ms`, `taper_ms`) under `loss.fb_seg`

## Testing
- `ruff check . | tail -n 20`
- `pip install yamllint` *(fails: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba3c86d840832ba399d6b1074e6912