### PR TITLE
Add optional trend-based prior for fb segmentation KL loss

### DIFF
--- a/proc/configs/base.yaml
+++ b/proc/configs/base.yaml
@@ -9,7 +9,7 @@ valid_field_list: train_field_list_tstkres.txt
 file_size: null
 
 # パス関連
-suffix: 'edgenext_small.usi_in1k_in1k_finetune_augspace01_modvelmask'
+suffix: 'edgenext_small.usi_in1k_in1k_finetune_augspace01_modvelmask_veltrend'
 
 # モデル関連（共通部分）
 backbone: edgenext_small.usi_in1k  # caformer_b36.sail_in22k_ft_in1k |edgenext_small.usi_in1k convnextv2_base.fcmae_ft_in22k_in1k_384
@@ -23,7 +23,7 @@ use_ema: True
 use_amp: True
 ema_decay: 0.99
 
-device: 'cuda'
+device: 'cuda:1'
 
 # Training task
 task: fb_seg  # recon | fb_seg
@@ -116,8 +116,20 @@ loss:
     vmax_mask: 6500.0    # m/s
     t0_lo_ms: -50.0      # ms
     t0_hi_ms: 80.0       # ms
-    taper_ms: 10.0       # ms
-
+    taper_ms: 10.0         # ms
+    vel_log_eps: 1.0e-4    # fp16安全な ε
+    vel_log_neg: -80.0     # ゼロ要素に与える大負値(soft-マスクのlog)
+    # --- trend-based prior ---
+    use_trend_prior: true      # まず有効化して挙動確認
+    prior_mode: logit          # 'logit' | 'kl'
+    prior_alpha: 0.05          # priorの強さ
+    prior_sigma_ms: 20.0       # ガウスpriorの標準偏差 [ms]
+    trend_section: 128         # セクション長
+    trend_stride: 64           # セクション間ストライド
+    trend_huber_c: 1.345       # Huber閾値
+    trend_vmin: 500.0          # トレンド推定での下限速度 [m/s]
+    trend_vmax: 6000.0         # トレンド推定での上限速度 [m/s]
+    prior_log_eps: 1.0e-4      # priorのlog安定化用 ε
 debug:
   audit_batches: 50          # 0 disables the audit
   audit_cov_threshold: 0.5   # coverage threshold to flag low-coverage valid traces

--- a/proc/configs/base.yaml
+++ b/proc/configs/base.yaml
@@ -122,14 +122,15 @@ loss:
     # --- trend-based prior ---
     use_trend_prior: true      # まず有効化して挙動確認
     prior_mode: logit          # 'logit' | 'kl'
-    prior_alpha: 0.05          # priorの強さ
-    prior_sigma_ms: 20.0       # ガウスpriorの標準偏差 [ms]
+    prior_alpha: 0.1         # priorの強さ
+    prior_sigma_ms: 50.0       # ガウスpriorの標準偏差 [ms]
     trend_section: 128         # セクション長
     trend_stride: 64           # セクション間ストライド
     trend_huber_c: 1.345       # Huber閾値
     trend_vmin: 500.0          # トレンド推定での下限速度 [m/s]
     trend_vmax: 6000.0         # トレンド推定での上限速度 [m/s]
     prior_log_eps: 1.0e-4      # priorのlog安定化用 ε
+    prior_conf_gate: 0.5
 debug:
   audit_batches: 50          # 0 disables the audit
   audit_cov_threshold: 0.5   # coverage threshold to flag low-coverage valid traces

--- a/proc/test.inference.py
+++ b/proc/test.inference.py
@@ -102,12 +102,12 @@ def debug_prior_visual(
 				sec_dir.mkdir(parents=True, exist_ok=True)
 
 				# ---- ロバスト回帰（このアイテムのみ）----
-				t_tr, s_tr, v_tr, _wconf = robust_linear_trend_sections(
-					offsets=offsets[b : b + 1],  # (1,H)
-					t_sec=pos_sec[b : b + 1],  # (1,H)
-					valid=valid[b : b + 1],  # (1,H)
-					prob=prob[b : b + 1],  # (1,H,W) ← 修正ポイント
-					dt_sec=dt_sec[b : b + 1],  # (1,1)
+				t_tr, s_tr, v_tr, w_conf, covered = robust_linear_trend_sections(
+					offsets=offsets[b : b + 1],
+					t_sec=pos_sec[b : b + 1],
+					valid=valid[b : b + 1],
+					prob=prob[b : b + 1],  # ← prob を渡す
+					dt_sec=dt_sec[b : b + 1],  # ← dt を渡す
 					section_len=section_len,
 					stride=stride,
 					huber_c=huber_c,
@@ -123,6 +123,7 @@ def debug_prior_visual(
 					W=W,
 					sigma_ms=prior_sigma_ms,
 					ref_tensor=logits[b : b + 1],
+					covered_mask=covered,  # ← 追加
 				)  # (1,H,W)
 
 				# ---- 数値診断 ----
@@ -135,14 +136,13 @@ def debug_prior_visual(
 					p99_ms = float(res_ms.quantile(0.99))
 				else:
 					med_ms = p95_ms = p99_ms = float('nan')
-
+				covered = covered.to(fb_idx.device)
 				log_p = torch.log_softmax(logit[b : b + 1] / tau, dim=-1)  # (1,H,W)
 				ce_bh = -(prior * log_p).sum(dim=-1)  # (1,H)
-				ce = (
-					float(ce_bh[valid[b : b + 1]].mean().cpu())
-					if valid[b].any()
-					else float('nan')
-				)
+
+				cov = covered[0]  # (H,)
+				use = (fb_idx[b] >= 0) & cov  # ← デバイス一致済み
+				ce = float(ce_bh[0, use].mean().cpu()) if use.any() else float('nan')
 
 				print(
 					f'[prior dbg] sec={section_counter:05d} (batch={batch_idx}, item={b}) '
@@ -225,7 +225,10 @@ def debug_prior_visual(
 				# pos_sec は有効だけ散布
 				ax2.plot(x_plot[valid_plot], pos_plot[valid_plot], '.', label='pos_sec')
 				# trend_t は NaN で分断された線として描く
-				ax2.plot(x_plot, tt_plot_masked, '-', label='trend_t (fit)')
+				cov = covered[0].cpu().numpy().astype(bool)
+				tt_plot = t_tr[0].cpu().numpy()
+				tt_plot[~cov] = float('nan')
+				ax2.plot(offsets[b].cpu().numpy(), tt_plot, '-', label='trend_t (fit)')
 				ax2.set_xlabel('offset [m]')
 				ax2.set_ylabel('time [s]')
 				ax2.legend(loc='best')

--- a/proc/test.inference.py
+++ b/proc/test.inference.py
@@ -1,0 +1,485 @@
+# %%
+# debug_prior_visual.py
+# build_val_loader_and_model.py
+import copy
+
+# debug_prior_visual_sections.py
+import csv
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from hydra import compose, initialize
+from torch.utils.data import DataLoader, Dataset, SequentialSampler
+
+from proc.util import MaskedSegyGather, segy_collate, worker_init_fn
+
+# loss.py からロバスト回帰だけ借ります
+from proc.util.loss import gaussian_prior_from_trend, robust_linear_trend_sections
+from proc.util.model import NetAE, adjust_first_conv_padding
+
+
+@torch.no_grad()
+def debug_prior_visual(
+	model,
+	loader,
+	device,
+	cfg_fb,
+	outdir='debug_prior_sections',
+	num_traces_to_plot=6,
+	max_sections=20,  # 走査するセクション数（アイテム数）の上限
+	section_stride=1,  # 等間引き（例: 5 なら 0,5,10,... を処理）
+):
+	"""DataLoader の“各セクション（=各アイテム）”単位で:
+	  推論 -> pos_sec -> ロバスト回帰 -> ガウスprior -> 数値診断/可視化 を実行。
+
+	生成物:
+	  - outdir/section_XXXXX/trace_prob_vs_prior.png
+	  - outdir/section_XXXXX/trend_over_offsets.png
+	  - outdir/section_XXXXX/vtrend_over_offsets.png
+	  - outdir/summary.csv（residual/CE の要約）
+	"""
+	model.eval()
+	outdir = Path(outdir)
+	outdir.mkdir(parents=True, exist_ok=True)
+
+	tau = float(getattr(cfg_fb, 'tau', 1.0))
+	prior_sigma_ms = float(getattr(cfg_fb, 'prior_sigma_ms', 20.0))
+	section_len = int(getattr(cfg_fb, 'trend_section', 128))
+	stride = int(getattr(cfg_fb, 'trend_stride', 64))
+	huber_c = float(getattr(cfg_fb, 'trend_huber_c', 1.345))
+	vmin = float(getattr(cfg_fb, 'trend_vmin', 500.0))
+	vmax = float(getattr(cfg_fb, 'trend_vmax', 5000.0))
+
+	# サマリ CSV
+	csv_path = outdir / 'summary.csv'
+	with open(csv_path, 'w', newline='') as fcsv:
+		writer = csv.writer(fcsv)
+		writer.writerow(
+			[
+				'section_idx',
+				'batch_idx',
+				'item_in_batch',
+				'B',
+				'H',
+				'W',
+				'sigma_ms',
+				'res_ms_median',
+				'res_ms_p95',
+				'res_ms_p99',
+				'ce_prior_p_mean',
+			]
+		)
+
+		section_counter = 0
+		for batch_idx, batch in enumerate(loader):
+			if (batch_idx % section_stride) != 0:
+				continue
+			if section_counter >= max_sections:
+				break
+
+			x_masked, x_tgt, mask_or_none, meta = batch
+			x_masked = x_masked.to(device, non_blocking=True)
+			logits = model(x_masked)  # (B,1,H,W)
+			logit = logits.squeeze(1)  # (B,H,W)
+			prob = torch.softmax(logit / tau, dim=-1)  # (B,H,W)
+			B, H, W = prob.shape
+			t_idx = torch.arange(W, device=prob.device, dtype=prob.dtype).view(1, 1, W)
+
+			dt_sec = meta['dt_sec'].to(prob).view(B, 1)  # (B,1)
+			offsets = meta['offsets'].to(prob)  # (B,H)
+			fb_idx = meta['fb_idx'].to(torch.long)  # (B,H)
+			valid = fb_idx > 0
+
+			# 期待位置（秒）
+			pos_samples = (prob * t_idx).sum(dim=-1)  # (B,H)
+			pos_sec = pos_samples * dt_sec  # (B,H)
+
+			# バッチ内の各アイテム（=各セクション）を個別に可視化する
+			for b in range(B):
+				sec_dir = outdir / f'section_{section_counter:05d}'
+				sec_dir.mkdir(parents=True, exist_ok=True)
+
+				# ---- ロバスト回帰（このアイテムのみ）----
+				t_tr, s_tr, v_tr, _wconf = robust_linear_trend_sections(
+					offsets=offsets[b : b + 1],  # (1,H)
+					t_sec=pos_sec[b : b + 1],  # (1,H)
+					valid=valid[b : b + 1],  # (1,H)
+					prob=prob[b : b + 1],  # (1,H,W) ← 修正ポイント
+					dt_sec=dt_sec[b : b + 1],  # (1,1)
+					section_len=section_len,
+					stride=stride,
+					huber_c=huber_c,
+					iters=3,
+					vmin=vmin,
+					vmax=vmax,
+				)  # 返りは (1,H)
+
+				# ---- prior 生成（このアイテムのみ）----
+				prior = gaussian_prior_from_trend(
+					t_trend_sec=t_tr,
+					dt_sec=dt_sec[b : b + 1],
+					W=W,
+					sigma_ms=prior_sigma_ms,
+					ref_tensor=logits[b : b + 1],
+				)  # (1,H,W)
+
+				# ---- 数値診断 ----
+				res = (pos_sec[b : b + 1] - t_tr).abs()  # (1,H)
+				res_valid = res[valid[b : b + 1]]
+				if res_valid.numel() > 0:
+					res_ms = (res_valid * 1e3).cpu()
+					med_ms = float(res_ms.median())
+					p95_ms = float(res_ms.quantile(0.95))
+					p99_ms = float(res_ms.quantile(0.99))
+				else:
+					med_ms = p95_ms = p99_ms = float('nan')
+
+				log_p = torch.log_softmax(logit[b : b + 1] / tau, dim=-1)  # (1,H,W)
+				ce_bh = -(prior * log_p).sum(dim=-1)  # (1,H)
+				ce = (
+					float(ce_bh[valid[b : b + 1]].mean().cpu())
+					if valid[b].any()
+					else float('nan')
+				)
+
+				print(
+					f'[prior dbg] sec={section_counter:05d} (batch={batch_idx}, item={b}) '
+					f'B=1 H={H} W={W}  sigma={prior_sigma_ms}ms  '
+					f'|pos-trend|ms: med={med_ms:.3f} p95={p95_ms:.3f} p99={p99_ms:.3f}  '
+					f'CE={ce:.5f}'
+				)
+				writer.writerow(
+					[
+						section_counter,
+						batch_idx,
+						b,
+						1,
+						H,
+						W,
+						prior_sigma_ms,
+						med_ms,
+						p95_ms,
+						p99_ms,
+						ce,
+					]
+				)
+
+				# ---- 可視化（このアイテムのみ）----
+				# 1) トレース上の p(t) と prior(t)
+				valid_idx = torch.nonzero(valid[b], as_tuple=False).squeeze(-1)
+				if valid_idx.numel() > 0:
+					k = min(num_traces_to_plot, int(valid_idx.numel()))
+					take = (
+						torch.linspace(0, valid_idx.numel() - 1, steps=k).round().long()
+					)
+					traces = valid_idx[take].tolist()
+
+					t_s = (
+						(t_idx * dt_sec[b : b + 1].view(1, 1)).squeeze().cpu().numpy()
+					)  # (W,)
+					fig = plt.figure(figsize=(12, 2.6 * k))
+					for j, h in enumerate(traces, start=1):
+						ax = fig.add_subplot(k, 1, j)
+						ax.plot(
+							t_s, prob[b, h].cpu().numpy(), label=f'prob (trace {h})'
+						)
+						ax.plot(
+							t_s,
+							prior[0, h].cpu().numpy(),
+							label=f'prior (σ={prior_sigma_ms}ms)',
+						)
+						ax.axvline(
+							float(t_tr[0, h].cpu()),
+							linestyle='--',
+							linewidth=1,
+							label='trend μ',
+						)
+						ax.set_xlim(t_s[0], t_s[-1])
+						ax.set_xlabel('time [s]')
+						ax.set_ylabel('prob')
+						ax.legend(loc='best')
+					fig.tight_layout()
+					fig.savefig(sec_dir / 'trace_prob_vs_prior.png', dpi=150)
+					plt.close(fig)
+
+				ord_idx = torch.argsort(offsets[b])
+				x_np = offsets[b].detach().cpu().numpy()
+				pos_np = pos_sec[b].detach().cpu().numpy()
+				tt_np = t_tr[0].detach().cpu().numpy()
+				valid_np = valid[b].detach().cpu().numpy().astype(bool)
+
+				# オフセット昇順に並べ替え（numpy で統一）
+				ord_idx = np.argsort(x_np)
+				x_plot = x_np[ord_idx]
+				pos_plot = pos_np[ord_idx]
+				tt_plot = tt_np[ord_idx]
+				valid_plot = valid_np[ord_idx]
+				# 無効トレースは線を切る（NaN にする）
+				tt_plot_masked = tt_plot.copy()
+				tt_plot_masked[~valid_plot] = np.nan
+
+				fig2 = plt.figure(figsize=(10, 4))
+				ax2 = fig2.add_subplot(1, 1, 1)
+				# pos_sec は有効だけ散布
+				ax2.plot(x_plot[valid_plot], pos_plot[valid_plot], '.', label='pos_sec')
+				# trend_t は NaN で分断された線として描く
+				ax2.plot(x_plot, tt_plot_masked, '-', label='trend_t (fit)')
+				ax2.set_xlabel('offset [m]')
+				ax2.set_ylabel('time [s]')
+				ax2.legend(loc='best')
+				fig2.tight_layout()
+				fig2.savefig(sec_dir / 'trend_over_offsets.png', dpi=150)
+				plt.close(fig2)
+
+				# --- 3) 見かけ速度 v_trend ---
+				v_plot = (1.0 / s_tr.clamp_min(1e-6))[0][ord_idx].cpu().numpy()
+				v_plot_masked = v_plot.copy()
+				v_plot_masked[~valid_plot] = np.nan
+
+				fig3 = plt.figure(figsize=(10, 3))
+				ax3 = fig3.add_subplot(1, 1, 1)
+				ax3.plot(x_plot, v_plot_masked, '-')
+				ax3.set_xlabel('offset [m]')
+				ax3.set_ylabel('v_trend [m/s]')
+				fig3.tight_layout()
+				fig3.savefig(sec_dir / 'vtrend_over_offsets.png', dpi=150)
+				plt.close(fig3)
+
+				section_counter += 1
+				if section_counter >= max_sections:
+					break
+
+	print(f'[prior dbg] saved summary to: {csv_path}')
+
+
+# build_val_loader_and_model.py
+
+import torch
+
+# ---- 1) Config / device ----
+with initialize(config_path='configs', version_base='1.3'):
+	cfg = compose(config_name='base')
+
+device = torch.device(cfg.device if torch.cuda.is_available() else 'cpu')
+
+
+# ---- 2) フィールドごとに .sgy/.npy を収集（最小版）----
+def collect_field_files(list_name: str, data_root: str):
+	list_path = Path('configs') / list_name
+	with open(list_path) as f:
+		fields = [
+			ln.strip() for ln in f if ln.strip() and not ln.strip().startswith('#')
+		]
+	segy_files, fb_files = [], []
+	for field in fields:
+		d = Path(data_root) / field
+		segy = sorted(list(d.glob('*.sgy')) + list(d.glob('*.segy')))
+		fb = sorted(d.glob('*.npy'))
+		if not segy or not fb:
+			print(f'[warn] skip: {field}')
+			continue
+		segy_files.append(segy[0])
+		fb_files.append(fb[0])
+	if not segy_files:
+		raise RuntimeError(f'No usable fields in {list_name}')
+	return segy_files, fb_files
+
+
+_, valid_fb_files = collect_field_files(cfg.valid_field_list, cfg.data_root)
+valid_segy_files, _ = collect_field_files(cfg.valid_field_list, cfg.data_root)
+
+# ---- 3) 検証用データセット（Augなし・flipなし）----
+valid_dataset_full = MaskedSegyGather(
+	valid_segy_files,
+	valid_fb_files,
+	mask_ratio=0,
+	mask_mode=cfg.dataset.mask_mode,
+	mask_noise_std=0,
+	target_mode=cfg.dataset.target_mode,
+	label_sigma=cfg.dataset.label_sigma,
+	flip=False,
+	augment_time_prob=0.0,
+	augment_space_prob=0.0,
+	augment_freq_prob=0.0,
+)
+
+
+# 「サンプル数を固定したい」場合は最初の n アイテムに凍結
+class FrozenValDataset(Dataset):
+	def __init__(self, items):
+		self.items = items
+
+	def __len__(self):
+		return len(self.items)
+
+	def __getitem__(self, i):
+		return self.items[i]
+
+
+n_val_item = cfg.val_steps * cfg.batch_size
+val_src = copy.copy(valid_dataset_full)  # file_infos を共有
+val_src.flip = False
+val_items = [val_src[i] for i in range(n_val_item)]
+valid_dataset = FrozenValDataset(val_items)
+
+# ---- 4) DataLoader（検証用）----
+val_loader = DataLoader(
+	valid_dataset,
+	batch_size=cfg.batch_size,
+	sampler=SequentialSampler(valid_dataset),
+	shuffle=False,
+	num_workers=0,
+	pin_memory=True,
+	collate_fn=segy_collate,
+	drop_last=False,
+	worker_init_fn=worker_init_fn,
+)
+
+# ---- 5) モデル構築 ----
+model = NetAE(
+	backbone=cfg.backbone,
+	pretrained=True,
+	stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+	pre_stages=2,
+	pre_stage_strides=((1, 1), (1, 2)),
+).to(device)
+
+if 'caformer' in cfg.backbone:
+	adjust_first_conv_padding(model.backbone, padding=(3, 3))
+
+# ---- 6) 重みの読み込み（EMA優先, なければ通常）----
+if getattr(cfg, 'resume', None):
+	ckpt = torch.load(cfg.resume, map_location='cpu', weights_only=False)
+	state = ckpt.get('model_ema', ckpt.get('model', ckpt))
+	missing, unexpected = model.load_state_dict(state, strict=False)
+	print(
+		f'[load] missing={len(missing)} unexpected={len(unexpected)} from {cfg.resume}'
+	)
+else:
+	print('[load] cfg.resume が未設定のため、ランダム初期化のまま')
+
+model.eval()
+
+# ---- 7) 動作確認（任意）：1バッチ取り出してデバイスに載せる ----
+if len(valid_dataset) > 0:
+	x_masked, x_tgt, mask_or_none, meta = next(iter(val_loader))
+	x_masked = x_masked.to(device, non_blocking=True)
+	with torch.no_grad():
+		_ = model(x_masked)
+	print('[check] val_loader 取り回し & モデル推論 OK')
+else:
+	print('[check] valid_dataset が空です')
+
+
+# ---- 1) Config / device ----
+with initialize(config_path='configs', version_base='1.3'):
+	cfg = compose(config_name='base')
+
+device = torch.device(cfg.device if torch.cuda.is_available() else 'cpu')
+
+
+# ---- 2) フィールドごとに .sgy/.npy を収集（最小版）----
+def collect_field_files(list_name: str, data_root: str):
+	list_path = Path('configs') / list_name
+	with open(list_path) as f:
+		fields = [
+			ln.strip() for ln in f if ln.strip() and not ln.strip().startswith('#')
+		]
+	segy_files, fb_files = [], []
+	for field in fields:
+		d = Path(data_root) / field
+		segy = sorted(list(d.glob('*.sgy')) + list(d.glob('*.segy')))
+		fb = sorted(d.glob('*.npy'))
+		if not segy or not fb:
+			print(f'[warn] skip: {field}')
+			continue
+		segy_files.append(segy[0])
+		fb_files.append(fb[0])
+	if not segy_files:
+		raise RuntimeError(f'No usable fields in {list_name}')
+	return segy_files, fb_files
+
+
+_, valid_fb_files = collect_field_files(cfg.valid_field_list, cfg.data_root)
+valid_segy_files, _ = collect_field_files(cfg.valid_field_list, cfg.data_root)
+
+# ---- 3) 検証用データセット（Augなし・flipなし）----
+valid_dataset_full = MaskedSegyGather(
+	valid_segy_files,
+	valid_fb_files,
+	mask_ratio=0,
+	mask_mode=cfg.dataset.mask_mode,
+	mask_noise_std=0,
+	target_mode=cfg.dataset.target_mode,
+	label_sigma=cfg.dataset.label_sigma,
+	flip=False,
+	augment_time_prob=0.0,
+	augment_space_prob=0.0,
+	augment_freq_prob=0.0,
+)
+
+
+# 「サンプル数を固定したい」場合は最初の n アイテムに凍結
+class FrozenValDataset(Dataset):
+	def __init__(self, items):
+		self.items = items
+
+	def __len__(self):
+		return len(self.items)
+
+	def __getitem__(self, i):
+		return self.items[i]
+
+
+n_val_item = cfg.val_steps * cfg.batch_size
+val_src = copy.copy(valid_dataset_full)  # file_infos を共有
+val_src.flip = False
+val_items = [val_src[i] for i in range(n_val_item)]
+valid_dataset = FrozenValDataset(val_items)
+
+# ---- 4) DataLoader（検証用）----
+val_loader = DataLoader(
+	valid_dataset,
+	batch_size=cfg.batch_size,
+	sampler=SequentialSampler(valid_dataset),
+	shuffle=False,
+	num_workers=0,
+	pin_memory=True,
+	collate_fn=segy_collate,
+	drop_last=False,
+	worker_init_fn=worker_init_fn,
+)
+
+# ---- 5) モデル構築 ----
+model = NetAE(
+	backbone=cfg.backbone,
+	pretrained=True,
+	stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+	pre_stages=2,
+	pre_stage_strides=((1, 1), (1, 2)),
+).to(device)
+
+if 'caformer' in cfg.backbone:
+	adjust_first_conv_padding(model.backbone, padding=(3, 3))
+
+# ---- 6) 重みの読み込み（EMA優先, なければ通常）----
+weight = '/workspace/proc/result/fb_seg/train_field_list_wotstkres_edgenext_b36.sail_in22k_ft_in1k_finetune_augspace01/model_180.pth'
+ckpt = torch.load(weight, map_location='cpu', weights_only=False)
+state = ckpt.get('model_ema', ckpt.get('model', ckpt))
+missing, unexpected = model.load_state_dict(state, strict=False)
+print(f'[load] missing={len(missing)} unexpected={len(unexpected)} from {cfg.resume}')
+
+model.eval()
+
+debug_prior_visual(
+	model,
+	val_loader,
+	device,
+	cfg.loss.fb_seg,
+	outdir='debug_prior',
+	num_traces_to_plot=6,
+)
+
+# %%

--- a/proc/train copy.py
+++ b/proc/train copy.py
@@ -1,0 +1,552 @@
+# %%
+import copy
+import datetime
+import os
+import random
+import shutil
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+from hydra import compose, initialize
+from torch.amp.grad_scaler import GradScaler
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler
+from torch.utils.data.distributed import DistributedSampler
+from torch.utils.tensorboard.writer import SummaryWriter
+
+from proc.eval import val_one_epoch_fbseg
+from proc.util import utils
+from proc.util.audit import audit_offsets_and_mask_coverage
+from proc.util.collate import segy_collate
+from proc.util.data_io import load_synth_pair
+from proc.util.dataset import MaskedSegyGather
+from proc.util.ema import ModelEMA
+from proc.util.eval import eval_synthe, val_one_epoch_snr
+from proc.util.loss import make_criterion, make_fb_seg_criterion
+from proc.util.model import NetAE, adjust_first_conv_padding
+from proc.util.predict import cover_all_traces_predict_chunked
+from proc.util.rng_util import worker_init_fn
+from proc.util.train_loop import train_one_epoch
+from proc.util.utils import WarmupCosineScheduler, collect_field_files, set_seed
+from proc.util.vis import visualize_pair_quartet
+
+
+def load_state_dict_excluding(
+	model: torch.nn.Module,
+	state: dict | str,
+	exclude_prefixes: tuple[str, ...] = ('seg_head',),
+	strict: bool = False,
+):
+	"""Load a checkpoint excluding parameters with given prefixes."""
+	if isinstance(state, str):
+		state = torch.load(state, map_location='cpu', weights_only=False)
+	sd = state.get('model_ema', state)
+	sd = {k: v for k, v in sd.items() if k.split('.')[0] not in exclude_prefixes}
+	missing, unexpected = model.load_state_dict(sd, strict=strict)
+	print(
+		f'[transfer] loaded {len(sd)} keys; missing={len(missing)} unexpected={len(unexpected)}'
+	)
+	return missing, unexpected
+
+
+SEED = 42
+set_seed(SEED)
+rng = np.random.default_rng()
+
+with initialize(config_path='configs', version_base='1.3'):
+	cfg = compose(config_name='base')
+
+if cfg.distributed:
+	torch.cuda.set_device(cfg.local_rank)
+	device = torch.device(cfg.device, cfg.local_rank)
+else:
+	device = torch.device(cfg.device if torch.cuda.is_available() else 'cpu')
+use_amp = cfg.use_amp
+scaler = GradScaler(enabled=use_amp)
+
+utils.init_distributed_mode(cfg)
+
+# Select loss function based on task
+criterion = make_criterion(cfg.loss)
+task = getattr(cfg, 'task', 'recon')
+if task == 'fb_seg':
+	criterion = make_fb_seg_criterion(cfg.loss.fb_seg)
+
+train_field_list = cfg.train_field_list
+valid_field_list = cfg.valid_field_list
+output_path = Path(f'./result/{task}/{train_field_list.split(".")[0]}_{cfg.suffix}')
+
+utils.mkdir(output_path)
+shutil.copy2('/workspace/proc/configs/base.yaml', output_path / 'config.yaml')
+
+
+train_segy_files, train_fb_files = collect_field_files(
+	cfg.train_field_list, cfg.data_root
+)
+valid_segy_files, valid_fb_files = collect_field_files(
+	cfg.valid_field_list, cfg.data_root
+)
+
+train_dataset = MaskedSegyGather(
+	train_segy_files,
+	train_fb_files,
+	mask_ratio=cfg.dataset.mask_ratio,
+	mask_mode=cfg.dataset.mask_mode,
+	mask_noise_std=cfg.dataset.mask_noise_std,
+	target_mode=cfg.dataset.target_mode,
+	label_sigma=cfg.dataset.label_sigma,
+	flip=cfg.dataset.flip,
+	augment_time_prob=cfg.dataset.augment.time.prob,
+	augment_time_range=tuple(cfg.dataset.augment.time.range),
+	augment_space_prob=cfg.dataset.augment.space.prob,
+	augment_space_range=tuple(cfg.dataset.augment.space.range),
+	augment_freq_prob=cfg.dataset.augment.freq.prob,
+	augment_freq_kinds=tuple(cfg.dataset.augment.freq.kinds),
+	augment_freq_band=tuple(cfg.dataset.augment.freq.band),
+	augment_freq_width=tuple(cfg.dataset.augment.freq.width),
+	augment_freq_roll=cfg.dataset.augment.freq.roll,
+	augment_freq_restandardize=cfg.dataset.augment.freq.restandardize,
+)
+if task == 'fb_seg':
+	valid_dataset = MaskedSegyGather(
+		valid_segy_files,
+		valid_fb_files,
+		mask_ratio=0,
+		mask_mode=cfg.dataset.mask_mode,
+		mask_noise_std=0,
+		target_mode=cfg.dataset.target_mode,
+		label_sigma=cfg.dataset.label_sigma,
+		flip=False,
+		augment_time_prob=0.0,
+		augment_space_prob=0.0,
+		augment_freq_prob=0.0,
+	)
+elif task == 'recon':
+	valid_dataset = MaskedSegyGather(
+		valid_segy_files,
+		valid_fb_files,
+		mask_ratio=cfg.dataset.mask_ratio,
+		mask_mode=cfg.dataset.mask_mode,
+		mask_noise_std=cfg.dataset.mask_noise_std,
+		target_mode=cfg.dataset.target_mode,
+		label_sigma=cfg.dataset.label_sigma,
+		flip=False,
+		augment_time_prob=0.0,
+		augment_space_prob=0.0,
+		augment_freq_prob=0.0,
+	)
+val_src = copy.copy(valid_dataset)  # file_infos を共有
+val_src.flip = False  # ここだけ無反転で取りたい場合
+
+n_val_item = (
+	cfg.val_steps * cfg.batch_size
+	if not cfg.distributed
+	else cfg.val_steps * cfg.batch_size * cfg.world_size
+)
+val_items = [val_src[i] for i in range(n_val_item)]
+val_src.close()
+
+
+class FrozenValDataset(Dataset):
+	def __init__(self, items):
+		self.items = items
+
+	def __len__(self):
+		return len(self.items)
+
+	def __getitem__(self, i):
+		return self.items[i]
+
+
+valid_dataset = FrozenValDataset(val_items)
+
+train_writer = SummaryWriter(os.path.join(output_path, 'logs', 'train'))
+valid_writer = SummaryWriter(os.path.join(output_path, 'logs', 'val'))
+
+if cfg.distributed:
+	train_sampler = DistributedSampler(
+		train_dataset,
+		shuffle=False,  # Dataset内部がランダム生成なのでshuffle不要
+		drop_last=True,
+	)
+else:
+	# 無限サンプリング的にreplacement=Trueにしてステップ数制御も可能
+	train_sampler = RandomSampler(
+		train_dataset,
+		replacement=True,  # for using num_samples
+		num_samples=cfg.steps_per_epoch * cfg.batch_size,  # 必要に応じて制御
+	)
+
+g = torch.Generator()
+g.manual_seed(SEED)
+
+train_loader = DataLoader(
+	train_dataset,
+	batch_size=cfg.batch_size,  # 固定4はやめてcfgから
+	sampler=train_sampler,  # ★samplerを使う
+	shuffle=False,  # ★sampler併用時はFalse
+	num_workers=cfg.num_workers,  # ここもcfgから
+	pin_memory=True,
+	collate_fn=segy_collate,  # ★必須
+	worker_init_fn=worker_init_fn,
+	drop_last=True,
+	generator=g,
+)
+
+if cfg.distributed:
+	n_val_item = cfg.val_steps * cfg.batch_size * cfg.world_size
+else:
+	n_val_item = cfg.val_steps * cfg.batch_size
+
+
+val_loader = DataLoader(
+	valid_dataset,
+	batch_size=cfg.batch_size,
+	sampler=SequentialSampler(valid_dataset),  # または shuffle=False
+	shuffle=False,
+	num_workers=0,  # 読むだけなので 0 で十分（>0でもOK）
+	pin_memory=True,
+	collate_fn=segy_collate,
+	drop_last=False,
+	worker_init_fn=worker_init_fn,
+)
+
+# -------- DEBUG AUDIT (run once before training) --------
+try:
+	audit_batches = int(getattr(getattr(cfg, 'debug', object()), 'audit_batches', 50))
+	cov_th = float(getattr(getattr(cfg, 'debug', object()), 'audit_cov_threshold', 0.5))
+except Exception:
+	audit_batches, cov_th = 50, 0.5
+
+if audit_batches > 0:
+	print(
+		f'[AUDIT] running audit on {audit_batches} batches (coverage threshold={cov_th})'
+	)
+	audit_offsets_and_mask_coverage(
+		train_loader, cfg.loss.fb_seg, max_batches=audit_batches, cov_threshold=cov_th
+	)
+	# Optionally also audit the validation loader:
+	# audit_offsets_and_mask_coverage(val_loader, cfg.loss.fb_seg, max_batches=min(20, audit_batches), cov_threshold=cov_th)
+print('[AUDIT] done.')
+
+synthe_noise_segy = (
+	'/home/dcuser/data/Synthetic/marmousi/shot801_decimate_fieldnoise008.sgy'
+)
+synthe_clean_segy = '/home/dcuser/data/Synthetic/marmousi/shotdata001_801_decimate.sgy'
+
+# 例) FFID 401 と 601 を抽出（W は 6016 に揃える）
+synthe_noisy, synthe_clean, _, used_ffids, Hs = load_synth_pair(
+	synthe_noise_segy,
+	synthe_clean_segy,
+	extract_key1idxs=[1, 401, 801, 1201, 1601],
+	target_len=6016,
+	standardize=True,
+	endian='little',
+)
+
+print(cfg.backbone)
+model = NetAE(
+	backbone=cfg.backbone,
+	pretrained=True,
+	stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+	pre_stages=2,
+	pre_stage_strides=(
+		(1, 1),
+		(1, 2),
+	),
+).to(device)
+
+if 'caformer' in cfg.backbone:
+	adjust_first_conv_padding(model.backbone, padding=(3, 3))
+
+if cfg.distributed and cfg.sync_bn:
+	model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
+epochs = cfg.epoch_block * cfg.num_block
+lr = cfg.lr * cfg.world_size
+step = 0
+
+base_lr = cfg.lr * cfg.world_size
+param_groups = [
+	{'params': model.seg_head.parameters(), 'lr': base_lr},
+]
+if hasattr(model, 'decoder'):
+	param_groups.append({'params': model.decoder.parameters(), 'lr': base_lr * 0.5})
+
+enc_params = [
+	p
+	for n, p in model.named_parameters()
+	if not n.startswith('seg_head') and not n.startswith('decoder')
+]
+if enc_params:
+	param_groups.append({'params': enc_params, 'lr': base_lr * 0.1})
+
+optimizer = torch.optim.AdamW(
+	param_groups,
+	betas=(0.9, 0.999),
+	weight_decay=cfg.weight_decay,
+)
+
+warmup_iters = cfg.lr_warmup_epochs * len(train_loader)
+
+lr_scheduler = WarmupCosineScheduler(
+	optimizer=optimizer,
+	warmup_steps=cfg.lr_warmup_epochs * len(train_loader),
+	total_steps=epochs * len(train_loader),
+	eta_min=1e-6,
+)
+
+model_without_ddp = model
+
+if cfg.distributed:
+	model = DistributedDataParallel(model, device_ids=[cfg.local_rank])
+	model_without_ddp = model.module
+
+transfer_loaded = False
+if cfg.resume:
+	transfer_loaded = True
+	checkpoint = torch.load(cfg.resume, map_location='cpu', weights_only=False)
+
+	# 1) モデル重みを読み込む（必要ならヘッドを除外）
+	if getattr(cfg, 'resume_exclude_head', False):
+		prefixes = tuple(getattr(cfg, 'resume_exclude_prefixes', ('seg_head',)))
+		load_state_dict_excluding(
+			model_without_ddp, checkpoint, exclude_prefixes=prefixes, strict=False
+		)
+	else:
+		model_state = checkpoint.get('model_ema', checkpoint)
+		model_without_ddp.load_state_dict(model_state, strict=False)
+
+	# 2) optimizer / lr_scheduler は基本読まない（明示フラグがある時のみ試す）
+	if getattr(cfg, 'resume_load_optim', False):
+		try:
+			opt_sd = checkpoint['optimizer']
+			if len(opt_sd['param_groups']) == len(optimizer.param_groups):
+				optimizer.load_state_dict(opt_sd)
+				if 'lr_scheduler' in checkpoint:
+					lr_scheduler.load_state_dict(checkpoint['lr_scheduler'])
+				cfg.start_epoch = int(checkpoint.get('epoch', -1)) + 1
+				step = int(checkpoint.get('step', 0))
+			else:
+				raise ValueError('param_groups mismatch')
+		except Exception as e:
+			print(
+				f'[resume] skip optimizer/scheduler: {e} -> reinit and restart from epoch 0'
+			)
+	else:
+		print('[resume] loaded model weights only (optimizer/scheduler reinitialized)')
+
+# 3) 段階解凍のガード用フラグ
+model._transfer_loaded = transfer_loaded
+
+if not cfg.distributed:
+	model = torch.compile(model, fullgraph=True, dynamic=False, mode='default')
+
+ema = (
+	ModelEMA(model_without_ddp, decay=cfg.ema_decay, device=device)
+	if cfg.use_ema
+	else None
+)
+
+if cfg.resume and ema:
+	print('Loading EMA model from checkpoint')
+	model_ema_state = checkpoint['model_ema']
+	ema.load_state_dict(model_ema_state, strict=False)
+
+eval_model = ema.module if ema else model
+
+print('Start training')
+start_time = time.time()
+best_mse = checkpoint.get('best_mse', float('inf')) if cfg.resume else float('inf')
+best_snr = checkpoint.get('best_snr', float('-inf')) if cfg.resume else float('-inf')
+chp = 1
+step = checkpoint.get('step', 0) if cfg.resume else 0
+
+for epoch in range(cfg.start_epoch, epochs):
+	if cfg.distributed:
+		train_sampler.set_epoch(epoch)
+
+	step = train_one_epoch(
+		model=model,
+		criterion=criterion,
+		optimizer=optimizer,
+		lr_scheduler=lr_scheduler,
+		dataloader=train_loader,
+		device=device,
+		epoch=epoch,
+		print_freq=cfg.print_freq,
+		writer=train_writer,
+		use_amp=use_amp,
+		scaler=scaler,
+		ema=ema,
+		gradient_accumulation_steps=1,
+		step=step,
+		freeze_epochs=cfg.freeze_epochs,
+		unfreeze_steps=cfg.unfreeze_steps,
+	)
+	eval_model = ema.module if ema else model
+
+	if task == 'recon':
+		snr_dict = val_one_epoch_snr(
+			eval_model,
+			val_loader,
+			device=device,
+			cfg_snr=cfg.snr,
+			visualize=True,
+			writer=valid_writer,
+			epoch=epoch,
+			is_main_process=utils.is_main_process(),
+			viz_batches=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+			if utils.is_main_process()
+			else (),
+		)
+
+		# 合成データ推論 & 指標
+		pred = cover_all_traces_predict_chunked(
+			eval_model,
+			synthe_noisy.to(device),
+			mask_noise_mode=cfg.dataset.mask_mode,
+			noise_std=cfg.dataset.mask_noise_std,
+		)
+		synthe_metrics = eval_synthe(synthe_clean, pred, device=device)
+		for i in range(len(synthe_noisy)):
+			visualize_pair_quartet(
+				synthe_noisy[:, :, :, :1251],
+				pred[:, :, :, :1251],
+				synthe_clean[:, :, :, :1251],
+				b=i,  # 1ショットのみ
+				transpose=True,
+				prefix='synth',
+				writer=valid_writer,
+				global_step=epoch,
+			)
+
+		# ── TensorBoard: エポック単位で記録 ──
+		if utils.is_main_process():
+			valid_writer.add_scalars(
+				'val_snr',
+				{
+					#'in_db': snr_dict['snr_in_db'],
+					'out_db': snr_dict['snr_out_db'],
+					#'improve_db': snr_dict['snr_improve_db'],
+				},
+				epoch,
+			)
+			# valid_writer.add_scalar('val_snr/valid_frac', snr_dict['valid_frac'], epoch)
+
+			valid_writer.add_scalar('val_synth/mse', synthe_metrics['mse'], epoch)
+			valid_writer.add_scalar('val_synth/mae', synthe_metrics['mae'], epoch)
+			valid_writer.add_scalar('val_synth/psnr', synthe_metrics['psnr'], epoch)
+			valid_writer.flush()
+
+		# ── ベスト更新（MSEは小さいほど良い / SNR改善は大きいほど良い） ──
+		save_flag = False
+		if synthe_metrics['mse'] < best_mse:
+			best_mse = synthe_metrics['mse']
+			save_flag = True
+		if snr_dict['snr_improve_db'] > best_snr:
+			best_snr = snr_dict['snr_improve_db']
+			save_flag = True
+
+		# チェックポイント作成
+		checkpoint = {
+			'model': model_without_ddp.state_dict(),
+			'optimizer': optimizer.state_dict(),
+			'lr_scheduler': lr_scheduler.state_dict(),
+			'epoch': epoch,
+			'step': step,
+			'cfg': cfg,
+			'best_mse': best_mse,
+			'best_snr': best_snr,
+			'rng_state': {
+				'torch': torch.get_rng_state(),
+				'cuda': torch.cuda.get_rng_state_all(),
+				'numpy': np.random.get_state(),
+				'random': random.getstate(),
+			},
+		}
+		if ema:
+			checkpoint['model_ema'] = ema.module.state_dict()
+
+		if save_flag:
+			utils.save_on_master(
+				checkpoint, os.path.join(output_path, 'checkpoint.pth')
+			)
+			print('saving checkpoint at epoch:', epoch)
+
+		print('epoch:', epoch)
+		print(
+			'  SNR in/out/Δ(dB):',
+			snr_dict['snr_in_db'],
+			snr_dict['snr_out_db'],
+			snr_dict['snr_improve_db'],
+		)
+		print('  best SNR Δ(dB):', best_snr)
+		print('  synth MSE/MAE/PSNR:', synthe_metrics)
+		print('  best MSE:', best_mse)
+	elif task == 'fb_seg':
+		fb_metrics = val_one_epoch_fbseg(
+			eval_model,
+			val_loader,
+			device=device,
+			visualize=True,
+			writer=valid_writer,
+			epoch=epoch,
+			viz_batches=(0, 1, 2, 3, 4),
+			cfg=cfg,
+		)
+		if utils.is_main_process():
+			valid_writer.add_scalar('fbseg/hit_at_0', fb_metrics['hit@0'], epoch)
+			valid_writer.add_scalar('fbseg/hit_at_2', fb_metrics['hit@2'], epoch)
+			valid_writer.add_scalar('fbseg/hit_at_4', fb_metrics['hit@4'], epoch)
+			valid_writer.add_scalar('fbseg/hit_at_8', fb_metrics['hit@8'], epoch)
+			valid_writer.add_scalar('fbseg/n_tr_valid', fb_metrics['n_tr_valid'], epoch)
+			valid_writer.flush()
+		checkpoint = {
+			'model': model_without_ddp.state_dict(),
+			'optimizer': optimizer.state_dict(),
+			'lr_scheduler': lr_scheduler.state_dict(),
+			'epoch': epoch,
+			'step': step,
+			'cfg': cfg,
+			'rng_state': {
+				'torch': torch.get_rng_state(),
+				'cuda': torch.cuda.get_rng_state_all(),
+				'numpy': np.random.get_state(),
+				'random': random.getstate(),
+			},
+		}
+		if ema:
+			checkpoint['model_ema'] = ema.module.state_dict()
+		print('epoch:', epoch)
+	else:
+		checkpoint = {
+			'model': model_without_ddp.state_dict(),
+			'optimizer': optimizer.state_dict(),
+			'lr_scheduler': lr_scheduler.state_dict(),
+			'epoch': epoch,
+			'step': step,
+			'cfg': cfg,
+			'rng_state': {
+				'torch': torch.get_rng_state(),
+				'cuda': torch.cuda.get_rng_state_all(),
+				'numpy': np.random.get_state(),
+				'random': random.getstate(),
+			},
+		}
+		if ema:
+			checkpoint['model_ema'] = ema.module.state_dict()
+		print('epoch:', epoch)
+
+	if output_path and (epoch + 1) % cfg.epoch_block == 0:
+		utils.save_on_master(
+			checkpoint, os.path.join(output_path, f'model_{epoch + 1}.pth')
+		)
+
+total_time = time.time() - start_time
+total_time_str = str(datetime.timedelta(seconds=int(total_time)))
+print(f'Training time {total_time_str}')
+
+# %%


### PR DESCRIPTION
## Summary
- augment KL fb-seg loss with optional trend-based Gaussian prior derived from current probabilities
- allow prior to act on logits or as a KL regularizer and expose its contribution in metrics

## Testing
- `python -m py_compile proc/util/loss.py`
- `ruff check proc/util/loss.py` *(fails: numerous existing style violations)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be3829f120832b97a51f91ec6e3c2e