### PR TITLE
Add optional per-shot offset channel for model input

### DIFF
--- a/proc/configs/base.yaml
+++ b/proc/configs/base.yaml
@@ -14,6 +14,8 @@ suffix: 'edgenext_small.usi_in1k_in1k_finetune_augspace01_modvelmask_veltrend'
 # モデル関連（共通部分）
 backbone: edgenext_small.usi_in1k  # caformer_b36.sail_in22k_ft_in1k |edgenext_small.usi_in1k convnextv2_base.fcmae_ft_in22k_in1k_384
 drop_path_rate: 0
+model:
+  use_offset_input: true  # set false to keep 1ch
 
 # 一般設定
 num_workers: 16

--- a/proc/eval.py
+++ b/proc/eval.py
@@ -100,18 +100,18 @@ def val_one_epoch_fbseg(
 	n_valid = 0
 	cfg_fb = cfg.loss.fb_seg
 	for i, (x, _, _, meta) in enumerate(val_loader):
-                x = x.to(device, non_blocking=True)
-                fb = meta['fb_idx'].to(device)
-                x_in = x
-                if (
-                        cfg is not None
-                        and getattr(getattr(cfg, 'model', None), 'use_offset_input', False)
-                        and ('offsets' in meta)
-                ):
-                        offs_ch = make_offset_channel(x, meta['offsets'])
-                        x_in = torch.cat([x, offs_ch], dim=1)
-                logits = model(x_in)
-                logit_raw = logits.squeeze(1)
+				x = x.to(device, non_blocking=True)
+				fb = meta['fb_idx'].to(device)
+				x_in = x
+				if (
+						cfg is not None
+						and getattr(getattr(cfg, 'model', None), 'use_offset_input', False)
+						and ('offsets' in meta)
+				):
+						offs_ch = make_offset_channel(x, meta['offsets'])
+						x_in = torch.cat([x, offs_ch], dim=1)
+				logits = model(x_in)
+				logit_raw = logits.squeeze(1)
 		B, H, W = logit_raw.shape
 
 		# === Always apply velocity-cone mask (match training) ===

--- a/proc/eval.py
+++ b/proc/eval.py
@@ -3,6 +3,7 @@ import numpy as np
 import torch
 
 from proc.util.velocity_mask import make_velocity_feasible_mask
+from proc.util.features import make_offset_channel
 
 __all__ = ['val_one_epoch_fbseg', 'visualize_fb_seg_triplet']
 
@@ -99,10 +100,18 @@ def val_one_epoch_fbseg(
 	n_valid = 0
 	cfg_fb = cfg.loss.fb_seg
 	for i, (x, _, _, meta) in enumerate(val_loader):
-		x = x.to(device, non_blocking=True)
-		fb = meta['fb_idx'].to(device)
-		logits = model(x)
-		logit_raw = logits.squeeze(1)
+                x = x.to(device, non_blocking=True)
+                fb = meta['fb_idx'].to(device)
+                x_in = x
+                if (
+                        cfg is not None
+                        and getattr(getattr(cfg, 'model', None), 'use_offset_input', False)
+                        and ('offsets' in meta)
+                ):
+                        offs_ch = make_offset_channel(x, meta['offsets'])
+                        x_in = torch.cat([x, offs_ch], dim=1)
+                logits = model(x_in)
+                logit_raw = logits.squeeze(1)
 		B, H, W = logit_raw.shape
 
 		# === Always apply velocity-cone mask (match training) ===

--- a/proc/test.inference.py
+++ b/proc/test.inference.py
@@ -17,19 +17,21 @@ from proc.util import MaskedSegyGather, segy_collate, worker_init_fn
 
 # loss.py からロバスト回帰だけ借ります
 from proc.util.loss import gaussian_prior_from_trend, robust_linear_trend_sections
-from proc.util.model import NetAE, adjust_first_conv_padding
+from proc.util.model import NetAE, adjust_first_conv_padding, inflate_first_conv_in
+from proc.util.features import make_offset_channel
 
 
 @torch.no_grad()
 def debug_prior_visual(
-	model,
-	loader,
-	device,
-	cfg_fb,
-	outdir='debug_prior_sections',
-	num_traces_to_plot=6,
-	max_sections=20,  # 走査するセクション数（アイテム数）の上限
-	section_stride=1,  # 等間引き（例: 5 なら 0,5,10,... を処理）
+        model,
+        loader,
+        device,
+        cfg_fb,
+        outdir='debug_prior_sections',
+        num_traces_to_plot=6,
+        max_sections=20,  # 走査するセクション数（アイテム数）の上限
+        section_stride=1,  # 等間引き（例: 5 なら 0,5,10,... を処理）
+        use_offset_input: bool = False,
 ):
 	"""DataLoader の“各セクション（=各アイテム）”単位で:
 	  推論 -> pos_sec -> ロバスト回帰 -> ガウスprior -> 数値診断/可視化 を実行。
@@ -79,9 +81,13 @@ def debug_prior_visual(
 			if section_counter >= max_sections:
 				break
 
-			x_masked, x_tgt, mask_or_none, meta = batch
-			x_masked = x_masked.to(device, non_blocking=True)
-			logits = model(x_masked)  # (B,1,H,W)
+                        x_masked, x_tgt, mask_or_none, meta = batch
+                        x_masked = x_masked.to(device, non_blocking=True)
+                        x_in = x_masked
+                        if use_offset_input and ('offsets' in meta):
+                                offs_ch = make_offset_channel(x_masked, meta['offsets'])
+                                x_in = torch.cat([x_masked, offs_ch], dim=1)
+                        logits = model(x_in)  # (B,1,H,W)
 			logit = logits.squeeze(1)  # (B,H,W)
 			prob = torch.softmax(logit / tau, dim=-1)  # (B,H,W)
 			B, H, W = prob.shape
@@ -342,15 +348,18 @@ val_loader = DataLoader(
 
 # ---- 5) モデル構築 ----
 model = NetAE(
-	backbone=cfg.backbone,
-	pretrained=True,
-	stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
-	pre_stages=2,
-	pre_stage_strides=((1, 1), (1, 2)),
+        backbone=cfg.backbone,
+        pretrained=True,
+        stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+        pre_stages=2,
+        pre_stage_strides=((1, 1), (1, 2)),
 ).to(device)
 
+if getattr(cfg.model, 'use_offset_input', False):
+        inflate_first_conv_in(model, in_ch=2)
+
 if 'caformer' in cfg.backbone:
-	adjust_first_conv_padding(model.backbone, padding=(3, 3))
+        adjust_first_conv_padding(model.backbone, padding=(3, 3))
 
 # ---- 6) 重みの読み込み（EMA優先, なければ通常）----
 if getattr(cfg, 'resume', None):
@@ -367,13 +376,17 @@ model.eval()
 
 # ---- 7) 動作確認（任意）：1バッチ取り出してデバイスに載せる ----
 if len(valid_dataset) > 0:
-	x_masked, x_tgt, mask_or_none, meta = next(iter(val_loader))
-	x_masked = x_masked.to(device, non_blocking=True)
-	with torch.no_grad():
-		_ = model(x_masked)
-	print('[check] val_loader 取り回し & モデル推論 OK')
+        x_masked, x_tgt, mask_or_none, meta = next(iter(val_loader))
+        x_masked = x_masked.to(device, non_blocking=True)
+        x_in = x_masked
+        if getattr(cfg.model, 'use_offset_input', False) and ('offsets' in meta):
+                offs_ch = make_offset_channel(x_masked, meta['offsets'])
+                x_in = torch.cat([x_masked, offs_ch], dim=1)
+        with torch.no_grad():
+                _ = model(x_in)
+        print('[check] val_loader 取り回し & モデル推論 OK')
 else:
-	print('[check] valid_dataset が空です')
+        print('[check] valid_dataset が空です')
 
 
 # ---- 1) Config / device ----
@@ -457,15 +470,18 @@ val_loader = DataLoader(
 
 # ---- 5) モデル構築 ----
 model = NetAE(
-	backbone=cfg.backbone,
-	pretrained=True,
-	stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
-	pre_stages=2,
-	pre_stage_strides=((1, 1), (1, 2)),
+        backbone=cfg.backbone,
+        pretrained=True,
+        stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+        pre_stages=2,
+        pre_stage_strides=((1, 1), (1, 2)),
 ).to(device)
 
+if getattr(cfg.model, 'use_offset_input', False):
+        inflate_first_conv_in(model, in_ch=2)
+
 if 'caformer' in cfg.backbone:
-	adjust_first_conv_padding(model.backbone, padding=(3, 3))
+        adjust_first_conv_padding(model.backbone, padding=(3, 3))
 
 # ---- 6) 重みの読み込み（EMA優先, なければ通常）----
 weight = '/workspace/proc/result/fb_seg/train_field_list_wotstkres_edgenext_b36.sail_in22k_ft_in1k_finetune_augspace01/model_180.pth'
@@ -477,12 +493,13 @@ print(f'[load] missing={len(missing)} unexpected={len(unexpected)} from {cfg.res
 model.eval()
 
 debug_prior_visual(
-	model,
-	val_loader,
-	device,
-	cfg.loss.fb_seg,
-	outdir='debug_prior',
-	num_traces_to_plot=6,
+        model,
+        val_loader,
+        device,
+        cfg.loss.fb_seg,
+        outdir='debug_prior',
+        num_traces_to_plot=6,
+        use_offset_input=getattr(cfg.model, 'use_offset_input', False),
 )
 
 # %%

--- a/proc/test.inference.py
+++ b/proc/test.inference.py
@@ -23,24 +23,24 @@ from proc.util.features import make_offset_channel
 
 @torch.no_grad()
 def debug_prior_visual(
-        model,
-        loader,
-        device,
-        cfg_fb,
-        outdir='debug_prior_sections',
-        num_traces_to_plot=6,
-        max_sections=20,  # 走査するセクション数（アイテム数）の上限
-        section_stride=1,  # 等間引き（例: 5 なら 0,5,10,... を処理）
-        use_offset_input: bool = False,
+		model,
+		loader,
+		device,
+		cfg_fb,
+		outdir='debug_prior_sections',
+		num_traces_to_plot=6,
+		max_sections=20,  # 走査するセクション数（アイテム数）の上限
+		section_stride=1,  # 等間引き（例: 5 なら 0,5,10,... を処理）
+		use_offset_input: bool = False,
 ):
 	"""DataLoader の“各セクション（=各アイテム）”単位で:
-	  推論 -> pos_sec -> ロバスト回帰 -> ガウスprior -> 数値診断/可視化 を実行。
+	推論 -> pos_sec -> ロバスト回帰 -> ガウスprior -> 数値診断/可視化 を実行。
 
 	生成物:
-	  - outdir/section_XXXXX/trace_prob_vs_prior.png
-	  - outdir/section_XXXXX/trend_over_offsets.png
-	  - outdir/section_XXXXX/vtrend_over_offsets.png
-	  - outdir/summary.csv（residual/CE の要約）
+	- outdir/section_XXXXX/trace_prob_vs_prior.png
+	- outdir/section_XXXXX/trend_over_offsets.png
+	- outdir/section_XXXXX/vtrend_over_offsets.png
+	- outdir/summary.csv（residual/CE の要約）
 	"""
 	model.eval()
 	outdir = Path(outdir)
@@ -81,13 +81,13 @@ def debug_prior_visual(
 			if section_counter >= max_sections:
 				break
 
-                        x_masked, x_tgt, mask_or_none, meta = batch
-                        x_masked = x_masked.to(device, non_blocking=True)
-                        x_in = x_masked
-                        if use_offset_input and ('offsets' in meta):
-                                offs_ch = make_offset_channel(x_masked, meta['offsets'])
-                                x_in = torch.cat([x_masked, offs_ch], dim=1)
-                        logits = model(x_in)  # (B,1,H,W)
+						x_masked, x_tgt, mask_or_none, meta = batch
+						x_masked = x_masked.to(device, non_blocking=True)
+						x_in = x_masked
+						if use_offset_input and ('offsets' in meta):
+								offs_ch = make_offset_channel(x_masked, meta['offsets'])
+								x_in = torch.cat([x_masked, offs_ch], dim=1)
+						logits = model(x_in)  # (B,1,H,W)
 			logit = logits.squeeze(1)  # (B,H,W)
 			prob = torch.softmax(logit / tau, dim=-1)  # (B,H,W)
 			B, H, W = prob.shape
@@ -348,18 +348,18 @@ val_loader = DataLoader(
 
 # ---- 5) モデル構築 ----
 model = NetAE(
-        backbone=cfg.backbone,
-        pretrained=True,
-        stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
-        pre_stages=2,
-        pre_stage_strides=((1, 1), (1, 2)),
+		backbone=cfg.backbone,
+		pretrained=True,
+		stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+		pre_stages=2,
+		pre_stage_strides=((1, 1), (1, 2)),
 ).to(device)
 
 if getattr(cfg.model, 'use_offset_input', False):
-        inflate_first_conv_in(model, in_ch=2)
+		inflate_first_conv_in(model, in_ch=2)
 
 if 'caformer' in cfg.backbone:
-        adjust_first_conv_padding(model.backbone, padding=(3, 3))
+		adjust_first_conv_padding(model.backbone, padding=(3, 3))
 
 # ---- 6) 重みの読み込み（EMA優先, なければ通常）----
 if getattr(cfg, 'resume', None):
@@ -376,17 +376,17 @@ model.eval()
 
 # ---- 7) 動作確認（任意）：1バッチ取り出してデバイスに載せる ----
 if len(valid_dataset) > 0:
-        x_masked, x_tgt, mask_or_none, meta = next(iter(val_loader))
-        x_masked = x_masked.to(device, non_blocking=True)
-        x_in = x_masked
-        if getattr(cfg.model, 'use_offset_input', False) and ('offsets' in meta):
-                offs_ch = make_offset_channel(x_masked, meta['offsets'])
-                x_in = torch.cat([x_masked, offs_ch], dim=1)
-        with torch.no_grad():
-                _ = model(x_in)
-        print('[check] val_loader 取り回し & モデル推論 OK')
+		x_masked, x_tgt, mask_or_none, meta = next(iter(val_loader))
+		x_masked = x_masked.to(device, non_blocking=True)
+		x_in = x_masked
+		if getattr(cfg.model, 'use_offset_input', False) and ('offsets' in meta):
+				offs_ch = make_offset_channel(x_masked, meta['offsets'])
+				x_in = torch.cat([x_masked, offs_ch], dim=1)
+		with torch.no_grad():
+				_ = model(x_in)
+		print('[check] val_loader 取り回し & モデル推論 OK')
 else:
-        print('[check] valid_dataset が空です')
+		print('[check] valid_dataset が空です')
 
 
 # ---- 1) Config / device ----
@@ -470,18 +470,18 @@ val_loader = DataLoader(
 
 # ---- 5) モデル構築 ----
 model = NetAE(
-        backbone=cfg.backbone,
-        pretrained=True,
-        stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
-        pre_stages=2,
-        pre_stage_strides=((1, 1), (1, 2)),
+		backbone=cfg.backbone,
+		pretrained=True,
+		stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+		pre_stages=2,
+		pre_stage_strides=((1, 1), (1, 2)),
 ).to(device)
 
 if getattr(cfg.model, 'use_offset_input', False):
-        inflate_first_conv_in(model, in_ch=2)
+		inflate_first_conv_in(model, in_ch=2)
 
 if 'caformer' in cfg.backbone:
-        adjust_first_conv_padding(model.backbone, padding=(3, 3))
+		adjust_first_conv_padding(model.backbone, padding=(3, 3))
 
 # ---- 6) 重みの読み込み（EMA優先, なければ通常）----
 weight = '/workspace/proc/result/fb_seg/train_field_list_wotstkres_edgenext_b36.sail_in22k_ft_in1k_finetune_augspace01/model_180.pth'
@@ -493,13 +493,13 @@ print(f'[load] missing={len(missing)} unexpected={len(unexpected)} from {cfg.res
 model.eval()
 
 debug_prior_visual(
-        model,
-        val_loader,
-        device,
-        cfg.loss.fb_seg,
-        outdir='debug_prior',
-        num_traces_to_plot=6,
-        use_offset_input=getattr(cfg.model, 'use_offset_input', False),
+		model,
+		val_loader,
+		device,
+		cfg.loss.fb_seg,
+		outdir='debug_prior',
+		num_traces_to_plot=6,
+		use_offset_input=getattr(cfg.model, 'use_offset_input', False),
 )
 
 # %%

--- a/proc/train.py
+++ b/proc/train.py
@@ -25,7 +25,7 @@ from proc.util.dataset import MaskedSegyGather
 from proc.util.ema import ModelEMA
 from proc.util.eval import eval_synthe, val_one_epoch_snr
 from proc.util.loss import make_criterion, make_fb_seg_criterion
-from proc.util.model import NetAE, adjust_first_conv_padding
+from proc.util.model import NetAE, adjust_first_conv_padding, inflate_first_conv_in
 from proc.util.predict import cover_all_traces_predict_chunked
 from proc.util.rng_util import worker_init_fn
 from proc.util.train_loop import train_one_epoch
@@ -248,18 +248,21 @@ synthe_noisy, synthe_clean, _, used_ffids, Hs = load_synth_pair(
 
 print(cfg.backbone)
 model = NetAE(
-	backbone=cfg.backbone,
-	pretrained=True,
-	stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
-	pre_stages=2,
-	pre_stage_strides=(
-		(1, 1),
-		(1, 2),
-	),
+        backbone=cfg.backbone,
+        pretrained=True,
+        stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+        pre_stages=2,
+        pre_stage_strides=(
+                (1, 1),
+                (1, 2),
+        ),
 ).to(device)
 
+if getattr(cfg.model, 'use_offset_input', False):
+        inflate_first_conv_in(model, in_ch=2)
+
 if 'caformer' in cfg.backbone:
-	adjust_first_conv_padding(model.backbone, padding=(3, 3))
+        adjust_first_conv_padding(model.backbone, padding=(3, 3))
 
 if cfg.distributed and cfg.sync_bn:
 	model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
@@ -368,48 +371,51 @@ for epoch in range(cfg.start_epoch, epochs):
 	if cfg.distributed:
 		train_sampler.set_epoch(epoch)
 
-	step = train_one_epoch(
-		model=model,
-		criterion=criterion,
-		optimizer=optimizer,
-		lr_scheduler=lr_scheduler,
-		dataloader=train_loader,
-		device=device,
-		epoch=epoch,
-		print_freq=cfg.print_freq,
-		writer=train_writer,
-		use_amp=use_amp,
-		scaler=scaler,
-		ema=ema,
-		gradient_accumulation_steps=1,
-		step=step,
-		freeze_epochs=cfg.freeze_epochs,
-		unfreeze_steps=cfg.unfreeze_steps,
-	)
+        step = train_one_epoch(
+                model=model,
+                criterion=criterion,
+                optimizer=optimizer,
+                lr_scheduler=lr_scheduler,
+                dataloader=train_loader,
+                device=device,
+                epoch=epoch,
+                print_freq=cfg.print_freq,
+                writer=train_writer,
+                use_amp=use_amp,
+                scaler=scaler,
+                ema=ema,
+                gradient_accumulation_steps=1,
+                step=step,
+                freeze_epochs=cfg.freeze_epochs,
+                unfreeze_steps=cfg.unfreeze_steps,
+                use_offset_input=getattr(cfg.model, 'use_offset_input', False),
+        )
 	eval_model = ema.module if ema else model
 
 	if task == 'recon':
-		snr_dict = val_one_epoch_snr(
-			eval_model,
-			val_loader,
-			device=device,
-			cfg_snr=cfg.snr,
-			visualize=True,
-			writer=valid_writer,
-			epoch=epoch,
-			is_main_process=utils.is_main_process(),
-			viz_batches=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-			if utils.is_main_process()
-			else (),
-		)
+                snr_dict = val_one_epoch_snr(
+                        eval_model,
+                        val_loader,
+                        device=device,
+                        cfg_snr=cfg.snr,
+                        visualize=True,
+                        writer=valid_writer,
+                        epoch=epoch,
+                        is_main_process=utils.is_main_process(),
+                        viz_batches=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+                        if utils.is_main_process()
+                        else (),
+                        use_offset_input=getattr(cfg.model, 'use_offset_input', False),
+                )
 
 		# 合成データ推論 & 指標
-		pred = cover_all_traces_predict_chunked(
-			eval_model,
-			synthe_noisy.to(device),
-			mask_noise_mode=cfg.dataset.mask_mode,
-			noise_std=cfg.dataset.mask_noise_std,
-		)
+                pred = cover_all_traces_predict_chunked(
+                        eval_model,
+                        synthe_noisy.to(device),
+                        mask_noise_mode=cfg.dataset.mask_mode,
+                        noise_std=cfg.dataset.mask_noise_std,
+                        use_offset_input=getattr(cfg.model, 'use_offset_input', False),
+                )
 		synthe_metrics = eval_synthe(synthe_clean, pred, device=device)
 		for i in range(len(synthe_noisy)):
 			visualize_pair_quartet(

--- a/proc/train.py
+++ b/proc/train.py
@@ -248,21 +248,21 @@ synthe_noisy, synthe_clean, _, used_ffids, Hs = load_synth_pair(
 
 print(cfg.backbone)
 model = NetAE(
-        backbone=cfg.backbone,
-        pretrained=True,
-        stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
-        pre_stages=2,
-        pre_stage_strides=(
-                (1, 1),
-                (1, 2),
-        ),
+		backbone=cfg.backbone,
+		pretrained=True,
+		stage_strides=[(2, 4), (2, 2), (2, 4), (2, 2)],
+		pre_stages=2,
+		pre_stage_strides=(
+				(1, 1),
+				(1, 2),
+		),
 ).to(device)
 
 if getattr(cfg.model, 'use_offset_input', False):
-        inflate_first_conv_in(model, in_ch=2)
+		inflate_first_conv_in(model, in_ch=2)
 
 if 'caformer' in cfg.backbone:
-        adjust_first_conv_padding(model.backbone, padding=(3, 3))
+		adjust_first_conv_padding(model.backbone, padding=(3, 3))
 
 if cfg.distributed and cfg.sync_bn:
 	model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
@@ -371,51 +371,51 @@ for epoch in range(cfg.start_epoch, epochs):
 	if cfg.distributed:
 		train_sampler.set_epoch(epoch)
 
-        step = train_one_epoch(
-                model=model,
-                criterion=criterion,
-                optimizer=optimizer,
-                lr_scheduler=lr_scheduler,
-                dataloader=train_loader,
-                device=device,
-                epoch=epoch,
-                print_freq=cfg.print_freq,
-                writer=train_writer,
-                use_amp=use_amp,
-                scaler=scaler,
-                ema=ema,
-                gradient_accumulation_steps=1,
-                step=step,
-                freeze_epochs=cfg.freeze_epochs,
-                unfreeze_steps=cfg.unfreeze_steps,
-                use_offset_input=getattr(cfg.model, 'use_offset_input', False),
-        )
+		step = train_one_epoch(
+				model=model,
+				criterion=criterion,
+				optimizer=optimizer,
+				lr_scheduler=lr_scheduler,
+				dataloader=train_loader,
+				device=device,
+				epoch=epoch,
+				print_freq=cfg.print_freq,
+				writer=train_writer,
+				use_amp=use_amp,
+				scaler=scaler,
+				ema=ema,
+				gradient_accumulation_steps=1,
+				step=step,
+				freeze_epochs=cfg.freeze_epochs,
+				unfreeze_steps=cfg.unfreeze_steps,
+				use_offset_input=getattr(cfg.model, 'use_offset_input', False),
+		)
 	eval_model = ema.module if ema else model
 
 	if task == 'recon':
-                snr_dict = val_one_epoch_snr(
-                        eval_model,
-                        val_loader,
-                        device=device,
-                        cfg_snr=cfg.snr,
-                        visualize=True,
-                        writer=valid_writer,
-                        epoch=epoch,
-                        is_main_process=utils.is_main_process(),
-                        viz_batches=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-                        if utils.is_main_process()
-                        else (),
-                        use_offset_input=getattr(cfg.model, 'use_offset_input', False),
-                )
+				snr_dict = val_one_epoch_snr(
+						eval_model,
+						val_loader,
+						device=device,
+						cfg_snr=cfg.snr,
+						visualize=True,
+						writer=valid_writer,
+						epoch=epoch,
+						is_main_process=utils.is_main_process(),
+						viz_batches=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+						if utils.is_main_process()
+						else (),
+						use_offset_input=getattr(cfg.model, 'use_offset_input', False),
+				)
 
 		# 合成データ推論 & 指標
-                pred = cover_all_traces_predict_chunked(
-                        eval_model,
-                        synthe_noisy.to(device),
-                        mask_noise_mode=cfg.dataset.mask_mode,
-                        noise_std=cfg.dataset.mask_noise_std,
-                        use_offset_input=getattr(cfg.model, 'use_offset_input', False),
-                )
+				pred = cover_all_traces_predict_chunked(
+						eval_model,
+						synthe_noisy.to(device),
+						mask_noise_mode=cfg.dataset.mask_mode,
+						noise_std=cfg.dataset.mask_noise_std,
+						use_offset_input=getattr(cfg.model, 'use_offset_input', False),
+				)
 		synthe_metrics = eval_synthe(synthe_clean, pred, device=device)
 		for i in range(len(synthe_noisy)):
 			visualize_pair_quartet(

--- a/proc/util/dataset.py
+++ b/proc/util/dataset.py
@@ -114,8 +114,8 @@ class MaskedSegyGather(Dataset):
 					chno_unique_keys=chno_unique_keys,
 					n_samples=f.samples.size,
 					n_traces=f.tracecount,
-                                        dt=dt,
-                                        dt_sec=dt_sec,
+										dt=dt,
+										dt_sec=dt_sec,
 					segy_obj=f,
 					fb=fb,
 					offsets=offsets,
@@ -199,11 +199,11 @@ class MaskedSegyGather(Dataset):
 			x = np.concatenate([x, pad_tr], axis=0)
 		x = x - np.mean(x, axis=1, keepdims=True)
 		x = x / (np.std(x, axis=1, keepdims=True) + 1e-10)
-                do_flip = self.flip and random.random() < 0.5
-                if do_flip:
-                        x = np.flip(x, axis=0).copy()
-                        fb_subset = fb_subset[::-1].copy()
-                        off_subset = off_subset[::-1].copy()
+				do_flip = self.flip and random.random() < 0.5
+				if do_flip:
+						x = np.flip(x, axis=0).copy()
+						fb_subset = fb_subset[::-1].copy()
+						off_subset = off_subset[::-1].copy()
 		factor = 1.0
 		if self.augment_time_prob > 0 and random.random() < self.augment_time_prob:
 			factor = random.uniform(*self.augment_time_range)

--- a/proc/util/dataset.py
+++ b/proc/util/dataset.py
@@ -199,10 +199,11 @@ class MaskedSegyGather(Dataset):
 			x = np.concatenate([x, pad_tr], axis=0)
 		x = x - np.mean(x, axis=1, keepdims=True)
 		x = x / (np.std(x, axis=1, keepdims=True) + 1e-10)
-		if self.flip and random.random() < 0.5:
-			x = np.flip(x, axis=0).copy()
-			fb_subset = fb_subset[::-1].copy()
-			off_subset = off_subset[::-1].copy()
+                do_flip = self.flip and random.random() < 0.5
+                if do_flip:
+                        x = np.flip(x, axis=0).copy()
+                        fb_subset = fb_subset[::-1].copy()
+                        off_subset = off_subset[::-1].copy()
 		factor = 1.0
 		if self.augment_time_prob > 0 and random.random() < self.augment_time_prob:
 			factor = random.uniform(*self.augment_time_range)

--- a/proc/util/eval.py
+++ b/proc/util/eval.py
@@ -11,17 +11,17 @@ __all__ = ['eval_synthe', 'val_one_epoch_snr']
 
 
 def val_one_epoch_snr(
-        model,
-        val_loader,
-        device,
-        cfg_snr,
-        visualize: bool = False,
-        viz_batches: tuple[int, ...] = (0,),
-        out_dir=None,
-        writer=None,
-        epoch: int | None = None,
-        is_main_process: bool = True,
-        use_offset_input: bool = False,
+		model,
+		val_loader,
+		device,
+		cfg_snr,
+		visualize: bool = False,
+		viz_batches: tuple[int, ...] = (0,),
+		out_dir=None,
+		writer=None,
+		epoch: int | None = None,
+		is_main_process: bool = True,
+		use_offset_input: bool = False,
 ):
 	"""Evaluate SNR improvement over validation loader."""
 	import matplotlib.pyplot as plt
@@ -31,19 +31,19 @@ def val_one_epoch_snr(
 	for i, (x_masked, x_orig, _, meta) in enumerate(val_loader):
 		x_orig = x_orig.to(device, non_blocking=True)
 		fb_idx = meta['fb_idx'].to(device)
-                y_full = cover_all_traces_predict(
-                        model,
-                        x_orig,
-                        mask_ratio=cfg_snr.mask_ratio_for_eval,
-                        noise_std=getattr(cfg_snr, 'noise_std', 1.0),
-                        use_amp=True,
-                        device=device,
-                        seed=cfg_snr.seed,
-                        passes_batch=cfg_snr.passes_batch,
-                        mask_noise_mode=getattr(cfg_snr, 'mask_noise_mode', 'replace'),
-                        offsets=meta.get('offsets'),
-                        use_offset_input=use_offset_input,
-                )
+				y_full = cover_all_traces_predict(
+						model,
+						x_orig,
+						mask_ratio=cfg_snr.mask_ratio_for_eval,
+						noise_std=getattr(cfg_snr, 'noise_std', 1.0),
+						use_amp=True,
+						device=device,
+						seed=cfg_snr.seed,
+						passes_batch=cfg_snr.passes_batch,
+						mask_noise_mode=getattr(cfg_snr, 'mask_noise_mode', 'replace'),
+						offsets=meta.get('offsets'),
+						use_offset_input=use_offset_input,
+				)
 		cache = prepare_fb_windows(
 			fb_idx,
 			W=x_orig.shape[-1],

--- a/proc/util/eval.py
+++ b/proc/util/eval.py
@@ -11,16 +11,17 @@ __all__ = ['eval_synthe', 'val_one_epoch_snr']
 
 
 def val_one_epoch_snr(
-	model,
-	val_loader,
-	device,
-	cfg_snr,
-	visualize: bool = False,
-	viz_batches: tuple[int, ...] = (0,),
-	out_dir=None,
-	writer=None,
-	epoch: int | None = None,
-	is_main_process: bool = True,
+        model,
+        val_loader,
+        device,
+        cfg_snr,
+        visualize: bool = False,
+        viz_batches: tuple[int, ...] = (0,),
+        out_dir=None,
+        writer=None,
+        epoch: int | None = None,
+        is_main_process: bool = True,
+        use_offset_input: bool = False,
 ):
 	"""Evaluate SNR improvement over validation loader."""
 	import matplotlib.pyplot as plt
@@ -30,17 +31,19 @@ def val_one_epoch_snr(
 	for i, (x_masked, x_orig, _, meta) in enumerate(val_loader):
 		x_orig = x_orig.to(device, non_blocking=True)
 		fb_idx = meta['fb_idx'].to(device)
-		y_full = cover_all_traces_predict(
-			model,
-			x_orig,
-			mask_ratio=cfg_snr.mask_ratio_for_eval,
-			noise_std=getattr(cfg_snr, 'noise_std', 1.0),
-			use_amp=True,
-			device=device,
-			seed=cfg_snr.seed,
-			passes_batch=cfg_snr.passes_batch,
-			mask_noise_mode=getattr(cfg_snr, 'mask_noise_mode', 'replace'),
-		)
+                y_full = cover_all_traces_predict(
+                        model,
+                        x_orig,
+                        mask_ratio=cfg_snr.mask_ratio_for_eval,
+                        noise_std=getattr(cfg_snr, 'noise_std', 1.0),
+                        use_amp=True,
+                        device=device,
+                        seed=cfg_snr.seed,
+                        passes_batch=cfg_snr.passes_batch,
+                        mask_noise_mode=getattr(cfg_snr, 'mask_noise_mode', 'replace'),
+                        offsets=meta.get('offsets'),
+                        use_offset_input=use_offset_input,
+                )
 		cache = prepare_fb_windows(
 			fb_idx,
 			W=x_orig.shape[-1],

--- a/proc/util/features.py
+++ b/proc/util/features.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import torch
+
+
+def make_offset_channel(x_masked: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+    """Build per-shot normalized offset channel.
+    x_masked : (B,1,H,W)
+    offsets  : (B,H) float/long; will be cast to x_masked
+    Returns  : (B,1,H,W)
+    """
+    B, _, H, W = x_masked.shape
+    offs = offsets.to(x_masked)
+    offs_c = offs - offs.median(dim=1, keepdim=True).values
+    scale = offs_c.abs().amax(dim=1, keepdim=True).clamp_min(1.0)
+    offs_n = offs_c / scale
+    offs_ch = offs_n.unsqueeze(-1).expand(-1, -1, W).unsqueeze(1)
+    return offs_ch

--- a/proc/util/features.py
+++ b/proc/util/features.py
@@ -4,15 +4,15 @@ import torch
 
 
 def make_offset_channel(x_masked: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
-    """Build per-shot normalized offset channel.
-    x_masked : (B,1,H,W)
-    offsets  : (B,H) float/long; will be cast to x_masked
-    Returns  : (B,1,H,W)
-    """
-    B, _, H, W = x_masked.shape
-    offs = offsets.to(x_masked)
-    offs_c = offs - offs.median(dim=1, keepdim=True).values
-    scale = offs_c.abs().amax(dim=1, keepdim=True).clamp_min(1.0)
-    offs_n = offs_c / scale
-    offs_ch = offs_n.unsqueeze(-1).expand(-1, -1, W).unsqueeze(1)
-    return offs_ch
+	"""Build per-shot normalized offset channel.
+	x_masked : (B,1,H,W)
+	offsets  : (B,H) float/long; will be cast to x_masked
+	Returns  : (B,1,H,W)
+	"""
+	B, _, H, W = x_masked.shape
+	offs = offsets.to(x_masked)
+	offs_c = offs - offs.median(dim=1, keepdim=True).values
+	scale = offs_c.abs().amax(dim=1, keepdim=True).clamp_min(1.0)
+	offs_n = offs_c / scale
+	offs_ch = offs_n.unsqueeze(-1).expand(-1, -1, W).unsqueeze(1)
+	return offs_ch

--- a/proc/util/model.py
+++ b/proc/util/model.py
@@ -6,41 +6,41 @@ from torch import nn
 
 
 def inflate_first_conv_in(model: nn.Module, in_ch: int) -> None:
-        """Replace first Conv2d to accept ``in_ch`` inputs by channel-averaging existing weights.
-        Tries common timm patterns: ``backbone.patch_embed.proj`` or ``backbone.stem[0]``.
-        Idempotent: if already matching, do nothing.
-        """
-        bb = getattr(model, "backbone", model)
+		"""Replace first Conv2d to accept ``in_ch`` inputs by channel-averaging existing weights.
+		Tries common timm patterns: ``backbone.patch_embed.proj`` or ``backbone.stem[0]``.
+		Idempotent: if already matching, do nothing.
+		"""
+		bb = getattr(model, "backbone", model)
 
-        conv = None
-        pe = getattr(bb, "patch_embed", None)
-        if pe is not None and hasattr(pe, "proj"):
-                conv = pe.proj
-        if conv is None and hasattr(bb, "stem"):
-                if (
-                        isinstance(bb.stem, nn.Sequential)
-                        and len(bb.stem) > 0
-                        and isinstance(bb.stem[0], nn.Conv2d)
-                ):
-                        conv = bb.stem[0]
-        if conv is None:
-                for m in bb.modules():
-                        if isinstance(m, nn.Conv2d):
-                                conv = m
-                                break
+		conv = None
+		pe = getattr(bb, "patch_embed", None)
+		if pe is not None and hasattr(pe, "proj"):
+				conv = pe.proj
+		if conv is None and hasattr(bb, "stem"):
+				if (
+						isinstance(bb.stem, nn.Sequential)
+						and len(bb.stem) > 0
+						and isinstance(bb.stem[0], nn.Conv2d)
+				):
+						conv = bb.stem[0]
+		if conv is None:
+				for m in bb.modules():
+						if isinstance(m, nn.Conv2d):
+								conv = m
+								break
 
-        if conv is None:
-                print("[warn] inflate_first_conv_in: first conv not found; skipped")
-                return
-        if conv.in_channels == in_ch:
-                return
+		if conv is None:
+				print("[warn] inflate_first_conv_in: first conv not found; skipped")
+				return
+		if conv.in_channels == in_ch:
+				return
 
-        with torch.no_grad():
-                W = conv.weight  # (out_c, old_in, kH, kW)
-                W_new = W.mean(dim=1, keepdim=True).repeat(1, in_ch, 1, 1).clone()
-                conv.weight = nn.Parameter(W_new)
-                conv.in_channels = in_ch
-        print(f"[model] inflated first conv to in_ch={in_ch}")
+		with torch.no_grad():
+				W = conv.weight  # (out_c, old_in, kH, kW)
+				W_new = W.mean(dim=1, keepdim=True).repeat(1, in_ch, 1, 1).clone()
+				conv.weight = nn.Parameter(W_new)
+				conv.in_channels = in_ch
+		print(f"[model] inflated first conv to in_ch={in_ch}")
 
 
 def adjust_first_conv_padding(backbone: nn.Module, padding=(1, 1)):

--- a/proc/util/predict.py
+++ b/proc/util/predict.py
@@ -11,18 +11,18 @@ __all__ = ['cover_all_traces_predict', 'cover_all_traces_predict_chunked']
 
 @torch.no_grad()
 def cover_all_traces_predict(
-        model: torch.nn.Module,
-        x: torch.Tensor,
-        *,
-        mask_ratio: float = 0.5,
-        noise_std: float = 1.0,
-        mask_noise_mode: Literal['replace', 'add'] = 'replace',
-        use_amp: bool = True,
-        device=None,
-        seed: int | None = 12345,
-        passes_batch: int = 4,
-        offsets: torch.Tensor | None = None,
-        use_offset_input: bool = False,
+		model: torch.nn.Module,
+		x: torch.Tensor,
+		*,
+		mask_ratio: float = 0.5,
+		noise_std: float = 1.0,
+		mask_noise_mode: Literal['replace', 'add'] = 'replace',
+		use_amp: bool = True,
+		device=None,
+		seed: int | None = 12345,
+		passes_batch: int = 4,
+		offsets: torch.Tensor | None = None,
+		use_offset_input: bool = False,
 ) -> torch.Tensor:
 	"""Predict each trace by covering all traces once.
 
@@ -43,59 +43,59 @@ def cover_all_traces_predict(
 		else:
 			perm = torch.randperm(H)
 		chunks = [perm[i : i + m] for i in range(0, H, m)]
-                for s in range(0, K, passes_batch):
-                        batch_chunks = chunks[s : s + passes_batch]
-                        xmb = []
-                        for idxs in batch_chunks:
-                                xm = x[b : b + 1].clone()
-                                if seed is not None:
-                                        gk = torch.Generator(device='cpu').manual_seed(
-                                                (seed + b) * 100003 + s * 1009 + int(idxs[0])
-                                        )
-                                        n = (
-                                                torch.randn((1, 1, len(idxs), W), generator=gk, device='cpu')
-                                                * noise_std
-                                        )
-                                else:
-                                        n = torch.randn((1, 1, len(idxs), W), device='cpu') * noise_std
-                                n = n.to(device=device, non_blocking=True)
-                                idxs_dev = idxs.to(device)
-                                if mask_noise_mode == 'replace':
-                                        xm[:, :, idxs_dev, :] = n
-                                elif mask_noise_mode == 'add':
-                                        xm[:, :, idxs_dev, :] += n
-                                else:
-                                        raise ValueError(f'Invalid mask_noise_mode: {mask_noise_mode}')
-                                if use_offset_input and offsets is not None:
-                                        off_b = offsets[b : b + 1]
-                                        offs_ch = make_offset_channel(xm, off_b)
-                                        xm = torch.cat([xm, offs_ch], dim=1)
-                                xmb.append(xm)
-                        xmb = torch.cat(xmb, dim=0)
-                        dev_type = 'cuda' if xmb.is_cuda else 'cpu'
-                        with autocast(device_type=dev_type, enabled=use_amp):
-                                yb = model(xmb)
-                        for k, idxs in enumerate(batch_chunks):
-                                y_full[b, :, idxs.to(device), :] = yb[k, :, idxs.to(device), :]
-        return y_full
+				for s in range(0, K, passes_batch):
+						batch_chunks = chunks[s : s + passes_batch]
+						xmb = []
+						for idxs in batch_chunks:
+								xm = x[b : b + 1].clone()
+								if seed is not None:
+										gk = torch.Generator(device='cpu').manual_seed(
+												(seed + b) * 100003 + s * 1009 + int(idxs[0])
+										)
+										n = (
+												torch.randn((1, 1, len(idxs), W), generator=gk, device='cpu')
+												* noise_std
+										)
+								else:
+										n = torch.randn((1, 1, len(idxs), W), device='cpu') * noise_std
+								n = n.to(device=device, non_blocking=True)
+								idxs_dev = idxs.to(device)
+								if mask_noise_mode == 'replace':
+										xm[:, :, idxs_dev, :] = n
+								elif mask_noise_mode == 'add':
+										xm[:, :, idxs_dev, :] += n
+								else:
+										raise ValueError(f'Invalid mask_noise_mode: {mask_noise_mode}')
+								if use_offset_input and offsets is not None:
+										off_b = offsets[b : b + 1]
+										offs_ch = make_offset_channel(xm, off_b)
+										xm = torch.cat([xm, offs_ch], dim=1)
+								xmb.append(xm)
+						xmb = torch.cat(xmb, dim=0)
+						dev_type = 'cuda' if xmb.is_cuda else 'cpu'
+						with autocast(device_type=dev_type, enabled=use_amp):
+								yb = model(xmb)
+						for k, idxs in enumerate(batch_chunks):
+								y_full[b, :, idxs.to(device), :] = yb[k, :, idxs.to(device), :]
+		return y_full
 
 
 @torch.no_grad()
 def cover_all_traces_predict_chunked(
-        model: torch.nn.Module,
-        x: torch.Tensor,
-        *,
-        chunk_h: int = 128,
-        overlap: int = 32,
-        mask_ratio: float = 0.5,
-        noise_std: float = 1.0,
-        mask_noise_mode: Literal['replace', 'add'] = 'replace',
-        use_amp: bool = True,
-        device=None,
-        seed: int = 12345,
-        passes_batch: int = 4,
-        offsets: torch.Tensor | None = None,
-        use_offset_input: bool = False,
+		model: torch.nn.Module,
+		x: torch.Tensor,
+		*,
+		chunk_h: int = 128,
+		overlap: int = 32,
+		mask_ratio: float = 0.5,
+		noise_std: float = 1.0,
+		mask_noise_mode: Literal['replace', 'add'] = 'replace',
+		use_amp: bool = True,
+		device=None,
+		seed: int = 12345,
+		passes_batch: int = 4,
+		offsets: torch.Tensor | None = None,
+		use_offset_input: bool = False,
 ) -> torch.Tensor:
 	"""Apply cover_all_traces_predict on tiled H-axis chunks.
 
@@ -113,20 +113,20 @@ def cover_all_traces_predict_chunked(
 	while s < H:
 		e = min(s + chunk_h, H)
 		xt = x[:, :, s:e, :]
-                offs_t = offsets[:, s:e] if offsets is not None else None
-                yt = cover_all_traces_predict(
-                        model,
-                        xt,
-                        mask_ratio=mask_ratio,
-                        noise_std=noise_std,
-                        mask_noise_mode=mask_noise_mode,
-                        use_amp=use_amp,
-                        device=device,
-                        seed=seed + s,
-                        passes_batch=passes_batch,
-                        offsets=offs_t,
-                        use_offset_input=use_offset_input,
-                )
+				offs_t = offsets[:, s:e] if offsets is not None else None
+				yt = cover_all_traces_predict(
+						model,
+						xt,
+						mask_ratio=mask_ratio,
+						noise_std=noise_std,
+						mask_noise_mode=mask_noise_mode,
+						use_amp=use_amp,
+						device=device,
+						seed=seed + s,
+						passes_batch=passes_batch,
+						offsets=offs_t,
+						use_offset_input=use_offset_input,
+				)
 		h_t = e - s
 		w = torch.ones((1, 1, h_t, 1), dtype=x.dtype, device=device)
 		left_ov = min(overlap, s)

--- a/proc/util/predict.py
+++ b/proc/util/predict.py
@@ -4,21 +4,25 @@ from typing import Literal
 import torch
 from torch.amp.autocast_mode import autocast
 
+from .features import make_offset_channel
+
 __all__ = ['cover_all_traces_predict', 'cover_all_traces_predict_chunked']
 
 
 @torch.no_grad()
 def cover_all_traces_predict(
-	model: torch.nn.Module,
-	x: torch.Tensor,
-	*,
-	mask_ratio: float = 0.5,
-	noise_std: float = 1.0,
-	mask_noise_mode: Literal['replace', 'add'] = 'replace',
-	use_amp: bool = True,
-	device=None,
-	seed: int | None = 12345,
-	passes_batch: int = 4,
+        model: torch.nn.Module,
+        x: torch.Tensor,
+        *,
+        mask_ratio: float = 0.5,
+        noise_std: float = 1.0,
+        mask_noise_mode: Literal['replace', 'add'] = 'replace',
+        use_amp: bool = True,
+        device=None,
+        seed: int | None = 12345,
+        passes_batch: int = 4,
+        offsets: torch.Tensor | None = None,
+        use_offset_input: bool = False,
 ) -> torch.Tensor:
 	"""Predict each trace by covering all traces once.
 
@@ -39,53 +43,59 @@ def cover_all_traces_predict(
 		else:
 			perm = torch.randperm(H)
 		chunks = [perm[i : i + m] for i in range(0, H, m)]
-		for s in range(0, K, passes_batch):
-			batch_chunks = chunks[s : s + passes_batch]
-			xmb = []
-			for idxs in batch_chunks:
-				xm = x[b : b + 1].clone()
-				if seed is not None:
-					gk = torch.Generator(device='cpu').manual_seed(
-						(seed + b) * 100003 + s * 1009 + int(idxs[0])
-					)
-					n = (
-						torch.randn((1, 1, len(idxs), W), generator=gk, device='cpu')
-						* noise_std
-					)
-				else:
-					n = torch.randn((1, 1, len(idxs), W), device='cpu') * noise_std
-				n = n.to(device=device, non_blocking=True)
-				idxs_dev = idxs.to(device)
-				if mask_noise_mode == 'replace':
-					xm[:, :, idxs_dev, :] = n
-				elif mask_noise_mode == 'add':
-					xm[:, :, idxs_dev, :] += n
-				else:
-					raise ValueError(f'Invalid mask_noise_mode: {mask_noise_mode}')
-				xmb.append(xm)
-			xmb = torch.cat(xmb, dim=0)
-			dev_type = 'cuda' if xmb.is_cuda else 'cpu'
-			with autocast(device_type=dev_type, enabled=use_amp):
-				yb = model(xmb)
-			for k, idxs in enumerate(batch_chunks):
-				y_full[b, :, idxs.to(device), :] = yb[k, :, idxs.to(device), :]
-	return y_full
+                for s in range(0, K, passes_batch):
+                        batch_chunks = chunks[s : s + passes_batch]
+                        xmb = []
+                        for idxs in batch_chunks:
+                                xm = x[b : b + 1].clone()
+                                if seed is not None:
+                                        gk = torch.Generator(device='cpu').manual_seed(
+                                                (seed + b) * 100003 + s * 1009 + int(idxs[0])
+                                        )
+                                        n = (
+                                                torch.randn((1, 1, len(idxs), W), generator=gk, device='cpu')
+                                                * noise_std
+                                        )
+                                else:
+                                        n = torch.randn((1, 1, len(idxs), W), device='cpu') * noise_std
+                                n = n.to(device=device, non_blocking=True)
+                                idxs_dev = idxs.to(device)
+                                if mask_noise_mode == 'replace':
+                                        xm[:, :, idxs_dev, :] = n
+                                elif mask_noise_mode == 'add':
+                                        xm[:, :, idxs_dev, :] += n
+                                else:
+                                        raise ValueError(f'Invalid mask_noise_mode: {mask_noise_mode}')
+                                if use_offset_input and offsets is not None:
+                                        off_b = offsets[b : b + 1]
+                                        offs_ch = make_offset_channel(xm, off_b)
+                                        xm = torch.cat([xm, offs_ch], dim=1)
+                                xmb.append(xm)
+                        xmb = torch.cat(xmb, dim=0)
+                        dev_type = 'cuda' if xmb.is_cuda else 'cpu'
+                        with autocast(device_type=dev_type, enabled=use_amp):
+                                yb = model(xmb)
+                        for k, idxs in enumerate(batch_chunks):
+                                y_full[b, :, idxs.to(device), :] = yb[k, :, idxs.to(device), :]
+        return y_full
 
 
 @torch.no_grad()
 def cover_all_traces_predict_chunked(
-	model: torch.nn.Module,
-	x: torch.Tensor,
-	*,
-	chunk_h: int = 128,
-	overlap: int = 32,
-	mask_ratio: float = 0.5,
-	noise_std: float = 1.0,
-	mask_noise_mode: Literal['replace', 'add'] = 'replace',
-	use_amp: bool = True,
-	device=None,
-	seed: int = 12345,
-	passes_batch: int = 4,
+        model: torch.nn.Module,
+        x: torch.Tensor,
+        *,
+        chunk_h: int = 128,
+        overlap: int = 32,
+        mask_ratio: float = 0.5,
+        noise_std: float = 1.0,
+        mask_noise_mode: Literal['replace', 'add'] = 'replace',
+        use_amp: bool = True,
+        device=None,
+        seed: int = 12345,
+        passes_batch: int = 4,
+        offsets: torch.Tensor | None = None,
+        use_offset_input: bool = False,
 ) -> torch.Tensor:
 	"""Apply cover_all_traces_predict on tiled H-axis chunks.
 
@@ -103,17 +113,20 @@ def cover_all_traces_predict_chunked(
 	while s < H:
 		e = min(s + chunk_h, H)
 		xt = x[:, :, s:e, :]
-		yt = cover_all_traces_predict(
-			model,
-			xt,
-			mask_ratio=mask_ratio,
-			noise_std=noise_std,
-			mask_noise_mode=mask_noise_mode,
-			use_amp=use_amp,
-			device=device,
-			seed=seed + s,
-			passes_batch=passes_batch,
-		)
+                offs_t = offsets[:, s:e] if offsets is not None else None
+                yt = cover_all_traces_predict(
+                        model,
+                        xt,
+                        mask_ratio=mask_ratio,
+                        noise_std=noise_std,
+                        mask_noise_mode=mask_noise_mode,
+                        use_amp=use_amp,
+                        device=device,
+                        seed=seed + s,
+                        passes_batch=passes_batch,
+                        offsets=offs_t,
+                        use_offset_input=use_offset_input,
+                )
 		h_t = e - s
 		w = torch.ones((1, 1, h_t, 1), dtype=x.dtype, device=device)
 		left_ov = min(overlap, s)

--- a/proc/util/train_loop.py
+++ b/proc/util/train_loop.py
@@ -6,8 +6,8 @@ from torch.nn.utils import clip_grad_norm_
 
 from proc.util import utils
 
-from .loss import shift_robust_l2_pertrace_vec
 from .features import make_offset_channel
+from .loss import shift_robust_l2_pertrace_vec
 
 
 def _finite_or_report(name, t, meta=None):
@@ -35,16 +35,16 @@ def _freeze_by_epoch(
 	Parameters
 	----------
 	model: torch.nn.Module
-	    Network with ``decoder`` and ``seg_head`` attributes.
+		Network with ``decoder`` and ``seg_head`` attributes.
 	epoch: int
-	    Current epoch index (0-based).
+		Current epoch index (0-based).
 	freeze_epochs: int
-	    Number of initial epochs during which only the head and the last
-	    decoder blocks are trained.
+		Number of initial epochs during which only the head and the last
+		decoder blocks are trained.
 	unfreeze_steps: int
-	    After ``freeze_epochs`` epochs, additional decoder blocks are
-	    unfrozen every ``unfreeze_steps`` epochs. Once all decoder blocks are
-	    unfrozen, the encoder (pre/down/backbone) is unfrozen as well.
+		After ``freeze_epochs`` epochs, additional decoder blocks are
+		unfrozen every ``unfreeze_steps`` epochs. Once all decoder blocks are
+		unfrozen, the encoder (pre/down/backbone) is unfrozen as well.
 
 	"""
 	if freeze_epochs <= 0 and unfreeze_steps <= 0:
@@ -109,8 +109,8 @@ def train_one_epoch(
 	max_shift=5,
 	step: int = 0,
 	freeze_epochs: int = 0,
-        unfreeze_steps: int = 1,
-        use_offset_input: bool = False,
+		unfreeze_steps: int = 1,
+		use_offset_input: bool = False,
 ):
 	"""Run one training epoch."""
 	if getattr(model, '_transfer_loaded', False) and freeze_epochs > 0:
@@ -190,14 +190,14 @@ def train_one_epoch(
 				for k in ('fb_idx', 'offsets', 'dt_sec'):
 					if k in meta and isinstance(meta[k], torch.Tensor):
 						meta[k] = meta[k][keep]
-                with autocast(device_type=device_type, enabled=use_amp):
-                        x_in = x_masked
-                        if use_offset_input and ('offsets' in meta):
-                                offs_ch = make_offset_channel(x_masked, meta['offsets'])
-                                x_in = torch.cat([x_masked, offs_ch], dim=1)
-                        pred = model(x_in)
-                        if not _finite_or_report("logits", pred, meta):
-                                print("[SKIP] non-finite logits; skipping batch")
+				with autocast(device_type=device_type, enabled=use_amp):
+						x_in = x_masked
+						if use_offset_input and ('offsets' in meta):
+								offs_ch = make_offset_channel(x_masked, meta['offsets'])
+								x_in = torch.cat([x_masked, offs_ch], dim=1)
+						pred = model(x_in)
+						if not _finite_or_report("logits", pred, meta):
+								print("[SKIP] non-finite logits; skipping batch")
 				optimizer.zero_grad(set_to_none=True)
 				continue
 			out = criterion(


### PR DESCRIPTION
## Summary
- support normalized per-shot offset channel as optional second input
- inflate model's first conv when using offset input
- propagate offset channel handling across training, evaluation, and inference

## Testing
- `ruff check proc` *(fails: RUF001 String contains ambiguous `−` (MINUS SIGN). Did you mean `-` (HYPHEN-MINUS)?)*
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError: from __future__ imports must occur at the beginning of the file)*

------
https://chatgpt.com/codex/tasks/task_e_68beb0b226c0832bb8cad4931bfbac2a