### PR TITLE
Add helper to compute normalization statistics

### DIFF
--- a/proc/configs/base.yaml
+++ b/proc/configs/base.yaml
@@ -9,13 +9,13 @@ valid_field_list: train_field_list_tstkres.txt
 file_size: null
 
 # パス関連
-suffix: edgenext_small.usi_in1k_in1k_default1_swprob05_secondrand
+suffix: edgenext_small.usi_in1k_in1k_default1_shot_secondvalid_reallinoffset
 
 norm:
-  offset_mode: log1p       # or "linear"
+  offset_mode: log1p      # or "linear"
   offset_clip_hi: 1.5
-  x95_m: 3000.0            # placeholder; will be computed from train set
-  t95_ms: 6000.0           # placeholder; will be computed from train set
+  x95_m: 8622.0            # placeholder; will be computed from train set
+  t95_ms: 16000.0           # placeholder; will be computed from train set
   time_clip_hi: 1.5
 
 # モデル関連（共通部分）
@@ -88,7 +88,7 @@ snr:
 
 dataset:
   primary_keys: [ffid, chno, cmp]        # 例: [ffid, chno, cmp] / [ffid] / [chno, cmp]
-  primary_key_weights: [0.33,0.33,0.33]  # 例: [0.7, 0.2, 0.1]  （長さは primary_keys に対応
+  primary_key_weights: null # 例: [0.7, 0.2, 0.1]  （長さは primary_keys に対応
   use_superwindow: true        # true で近傍 primary を結合（非平均）
   sw_halfspan: 1                # ±いくつ結合するか（0で無効）
   sw_prob: 0.5

--- a/proc/configs/inference.yaml
+++ b/proc/configs/inference.yaml
@@ -13,7 +13,7 @@ infer:
   valid_field_list: ${valid_field_list}
 
   # 必須: チェックポイントパス（HydraのCLIで override 可能）
-  ckpt: /workspace/proc/result/fb_seg/train_field_list_wotstkres_edgenext_small.usi_in1k_in1k_default1_swprob05_secondvalid/model_80.pth
+  ckpt: /workspace/proc/result/fb_seg/train_field_list_wotstkres_edgenext_small.usi_in1k_in1k_default1_shotcmpchno_secondrand_realoffset_addsuper/model_100.pth
   # 評価ドメイン（shot=FFID, recv=CHNO, cmp=CMP, super=shotに対するsuperwindow）
   domains: [shot, recv, cmp]
 

--- a/proc/debug/compute_norm_stats.py
+++ b/proc/debug/compute_norm_stats.py
@@ -1,0 +1,189 @@
+"""Helper script to compute robust normalization statistics for training."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+from hydra import compose, initialize
+
+from proc.util.dataset import MaskedSegyGather
+
+
+def _resolve_field_list_path(list_name: str) -> Path:
+    """Return the path to the field list file, searching common locations."""
+
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parents[1] / 'configs' / list_name,
+        here.parents[2] / 'configs' / list_name,
+    ]
+    for cand in candidates:
+        if cand.exists():
+            return cand
+    raise FileNotFoundError(
+        f'Field list not found for {list_name!r}; looked in: '
+        f"{', '.join(str(c) for c in candidates)}"
+    )
+
+
+def _collect_field_files(list_name: str, data_root: str) -> tuple[list[Path], list[Path]]:
+    """Collect SEG-Y and label file pairs listed in ``list_name``."""
+
+    list_path = _resolve_field_list_path(list_name)
+    with list_path.open() as f:
+        fields = [
+            ln.strip() for ln in f if ln.strip() and not ln.strip().startswith('#')
+        ]
+
+    segy_files: list[Path] = []
+    fb_files: list[Path] = []
+    for field in fields:
+        base = Path(data_root) / field
+        segy_candidates = sorted(list(base.glob('*.sgy')) + list(base.glob('*.segy')))
+        fb_candidates = sorted(base.glob('*.npy'))
+        if not segy_candidates or not fb_candidates:
+            print(f'[WARN] Skipping {field}: missing SEG-Y or FB files')
+            continue
+        segy_files.append(segy_candidates[0])
+        fb_files.append(fb_candidates[0])
+
+    if not segy_files:
+        raise RuntimeError(f'No usable SEG-Y files found for list {list_name!r}')
+
+    return segy_files, fb_files
+
+
+def _build_train_dataset(cfg, data_root: str, field_list: str) -> MaskedSegyGather:
+    """Instantiate the training dataset with the same configuration as training."""
+
+    segy_files, fb_files = _collect_field_files(field_list, data_root)
+
+    dataset_cfg = getattr(cfg, 'dataset', object())
+    augment_cfg = getattr(dataset_cfg, 'augment', None)
+    time_cfg = getattr(augment_cfg, 'time', None) if augment_cfg is not None else None
+    space_cfg = getattr(augment_cfg, 'space', None) if augment_cfg is not None else None
+    freq_cfg = getattr(augment_cfg, 'freq', None) if augment_cfg is not None else None
+    return MaskedSegyGather(
+        [str(p) for p in segy_files],
+        [str(p) for p in fb_files],
+        primary_keys=getattr(dataset_cfg, 'primary_keys', None),
+        primary_key_weights=getattr(dataset_cfg, 'primary_key_weights', None),
+        use_header_cache=getattr(dataset_cfg, 'use_header_cache', False),
+        header_cache_dir=getattr(dataset_cfg, 'header_cache_dir', None),
+        use_superwindow=getattr(dataset_cfg, 'use_superwindow', False),
+        sw_halfspan=getattr(dataset_cfg, 'sw_halfspan', 0),
+        sw_prob=getattr(dataset_cfg, 'sw_prob', 0.3),
+        mask_ratio=getattr(dataset_cfg, 'mask_ratio', 0.0),
+        mask_mode=getattr(dataset_cfg, 'mask_mode', 'replace'),
+        mask_noise_std=getattr(dataset_cfg, 'mask_noise_std', 1.0),
+        target_mode=getattr(dataset_cfg, 'target_mode', 'recon'),
+        label_sigma=getattr(dataset_cfg, 'label_sigma', 1.0),
+        flip=getattr(dataset_cfg, 'flip', False),
+        augment_time_prob=getattr(time_cfg, 'prob', 0.0),
+        augment_time_range=tuple(getattr(time_cfg, 'range', (0.95, 1.05)))
+        if time_cfg is not None
+        else (0.95, 1.05),
+        augment_space_prob=getattr(space_cfg, 'prob', 0.0),
+        augment_space_range=tuple(getattr(space_cfg, 'range', (0.90, 1.10)))
+        if space_cfg is not None
+        else (0.90, 1.10),
+        augment_freq_prob=getattr(freq_cfg, 'prob', 0.0),
+        augment_freq_kinds=tuple(getattr(freq_cfg, 'kinds', ()))
+        if freq_cfg is not None
+        else tuple(),
+        augment_freq_band=tuple(getattr(freq_cfg, 'band', (0.05, 0.45)))
+        if freq_cfg is not None
+        else (0.05, 0.45),
+        augment_freq_width=tuple(getattr(freq_cfg, 'width', (0.10, 0.35)))
+        if freq_cfg is not None
+        else (0.10, 0.35),
+        augment_freq_roll=getattr(freq_cfg, 'roll', 0.02) if freq_cfg is not None else 0.02,
+        augment_freq_restandardize=getattr(freq_cfg, 'restandardize', True)
+        if freq_cfg is not None
+        else True,
+        reject_fblc=getattr(dataset_cfg, 'reject_fblc', False),
+        fblc_percentile=getattr(dataset_cfg, 'fblc_percentile', 95.0),
+        fblc_thresh_ms=getattr(dataset_cfg, 'fblc_thresh_ms', 8.0),
+        fblc_min_pairs=getattr(dataset_cfg, 'fblc_min_pairs', 16),
+        fblc_apply_on=getattr(dataset_cfg, 'fblc_apply_on', 'any'),
+        valid=False,
+    )
+
+
+def compute_norm_stats(
+    cfg,
+    *,
+    data_root: str,
+    train_field_list: str,
+) -> tuple[float, float]:
+    """Compute the 95th percentile statistics for offsets and record lengths."""
+
+    dataset = _build_train_dataset(cfg, data_root=data_root, field_list=train_field_list)
+    try:
+        all_offsets: list[np.ndarray] = []
+        all_tend_ms: list[float] = []
+
+        for info in dataset.file_infos:
+            offsets = np.asarray(info.get('offsets', []), dtype=np.float64)
+            if offsets.size:
+                all_offsets.append(offsets)
+
+            n_samples = int(info.get('n_samples', 0))
+            dt_sec = float(info.get('dt_sec', 0.0))
+            all_tend_ms.append(n_samples * dt_sec * 1000.0)
+
+        if not all_offsets:
+            raise RuntimeError('No offsets collected from training dataset.')
+
+        offsets_concat = np.concatenate(all_offsets)
+        x95_m = float(np.percentile(offsets_concat, 95))
+        t95_ms = float(np.percentile(np.asarray(all_tend_ms, dtype=np.float64), 95))
+        return x95_m, t95_ms
+    finally:
+        dataset.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Compute robust normalization statistics from the training split.'
+    )
+    parser.add_argument(
+        '--data_root',
+        type=str,
+        default=None,
+        help='Override the dataset root directory (defaults to cfg.data_root).',
+    )
+    parser.add_argument(
+        '--train_field_list',
+        type=str,
+        default=None,
+        help='Override the training field list file (defaults to cfg.train_field_list).',
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    with initialize(config_path='../configs', version_base='1.3'):
+        cfg = compose(config_name='base')
+
+    data_root = args.data_root or cfg.data_root
+    train_field_list = args.train_field_list or cfg.train_field_list
+
+    x95_m, t95_ms = compute_norm_stats(
+        cfg,
+        data_root=data_root,
+        train_field_list=train_field_list,
+    )
+
+    print('norm:')
+    print(f'  x95_m: {x95_m:.4f}')
+    print(f'  t95_ms: {t95_ms:.4f}')
+
+
+if __name__ == '__main__':
+    main()
+

--- a/proc/debug/compute_norm_stats.py
+++ b/proc/debug/compute_norm_stats.py
@@ -1,5 +1,6 @@
 """Helper script to compute robust normalization statistics for training."""
 
+# %%
 from __future__ import annotations
 
 import argparse
@@ -12,178 +13,179 @@ from proc.util.dataset import MaskedSegyGather
 
 
 def _resolve_field_list_path(list_name: str) -> Path:
-    """Return the path to the field list file, searching common locations."""
+	"""Return the path to the field list file, searching common locations."""
+	here = Path(__file__).resolve()
+	candidates = [
+		here.parents[1] / 'configs' / list_name,
+		here.parents[2] / 'configs' / list_name,
+	]
+	for cand in candidates:
+		if cand.exists():
+			return cand
+	raise FileNotFoundError(
+		f'Field list not found for {list_name!r}; looked in: '
+		f'{", ".join(str(c) for c in candidates)}'
+	)
 
-    here = Path(__file__).resolve()
-    candidates = [
-        here.parents[1] / 'configs' / list_name,
-        here.parents[2] / 'configs' / list_name,
-    ]
-    for cand in candidates:
-        if cand.exists():
-            return cand
-    raise FileNotFoundError(
-        f'Field list not found for {list_name!r}; looked in: '
-        f"{', '.join(str(c) for c in candidates)}"
-    )
 
+def _collect_field_files(
+	list_name: str, data_root: str
+) -> tuple[list[Path], list[Path]]:
+	"""Collect SEG-Y and label file pairs listed in ``list_name``."""
+	list_path = _resolve_field_list_path(list_name)
+	with list_path.open() as f:
+		fields = [
+			ln.strip() for ln in f if ln.strip() and not ln.strip().startswith('#')
+		]
 
-def _collect_field_files(list_name: str, data_root: str) -> tuple[list[Path], list[Path]]:
-    """Collect SEG-Y and label file pairs listed in ``list_name``."""
+	segy_files: list[Path] = []
+	fb_files: list[Path] = []
+	for field in fields:
+		base = Path(data_root) / field
+		segy_candidates = sorted(list(base.glob('*.sgy')) + list(base.glob('*.segy')))
+		fb_candidates = sorted(base.glob('*.npy'))
+		if not segy_candidates or not fb_candidates:
+			print(f'[WARN] Skipping {field}: missing SEG-Y or FB files')
+			continue
+		segy_files.append(segy_candidates[0])
+		fb_files.append(fb_candidates[0])
 
-    list_path = _resolve_field_list_path(list_name)
-    with list_path.open() as f:
-        fields = [
-            ln.strip() for ln in f if ln.strip() and not ln.strip().startswith('#')
-        ]
+	if not segy_files:
+		raise RuntimeError(f'No usable SEG-Y files found for list {list_name!r}')
 
-    segy_files: list[Path] = []
-    fb_files: list[Path] = []
-    for field in fields:
-        base = Path(data_root) / field
-        segy_candidates = sorted(list(base.glob('*.sgy')) + list(base.glob('*.segy')))
-        fb_candidates = sorted(base.glob('*.npy'))
-        if not segy_candidates or not fb_candidates:
-            print(f'[WARN] Skipping {field}: missing SEG-Y or FB files')
-            continue
-        segy_files.append(segy_candidates[0])
-        fb_files.append(fb_candidates[0])
-
-    if not segy_files:
-        raise RuntimeError(f'No usable SEG-Y files found for list {list_name!r}')
-
-    return segy_files, fb_files
+	return segy_files, fb_files
 
 
 def _build_train_dataset(cfg, data_root: str, field_list: str) -> MaskedSegyGather:
-    """Instantiate the training dataset with the same configuration as training."""
+	"""Instantiate the training dataset with the same configuration as training."""
+	segy_files, fb_files = _collect_field_files(field_list, data_root)
 
-    segy_files, fb_files = _collect_field_files(field_list, data_root)
-
-    dataset_cfg = getattr(cfg, 'dataset', object())
-    augment_cfg = getattr(dataset_cfg, 'augment', None)
-    time_cfg = getattr(augment_cfg, 'time', None) if augment_cfg is not None else None
-    space_cfg = getattr(augment_cfg, 'space', None) if augment_cfg is not None else None
-    freq_cfg = getattr(augment_cfg, 'freq', None) if augment_cfg is not None else None
-    return MaskedSegyGather(
-        [str(p) for p in segy_files],
-        [str(p) for p in fb_files],
-        primary_keys=getattr(dataset_cfg, 'primary_keys', None),
-        primary_key_weights=getattr(dataset_cfg, 'primary_key_weights', None),
-        use_header_cache=getattr(dataset_cfg, 'use_header_cache', False),
-        header_cache_dir=getattr(dataset_cfg, 'header_cache_dir', None),
-        use_superwindow=getattr(dataset_cfg, 'use_superwindow', False),
-        sw_halfspan=getattr(dataset_cfg, 'sw_halfspan', 0),
-        sw_prob=getattr(dataset_cfg, 'sw_prob', 0.3),
-        mask_ratio=getattr(dataset_cfg, 'mask_ratio', 0.0),
-        mask_mode=getattr(dataset_cfg, 'mask_mode', 'replace'),
-        mask_noise_std=getattr(dataset_cfg, 'mask_noise_std', 1.0),
-        target_mode=getattr(dataset_cfg, 'target_mode', 'recon'),
-        label_sigma=getattr(dataset_cfg, 'label_sigma', 1.0),
-        flip=getattr(dataset_cfg, 'flip', False),
-        augment_time_prob=getattr(time_cfg, 'prob', 0.0),
-        augment_time_range=tuple(getattr(time_cfg, 'range', (0.95, 1.05)))
-        if time_cfg is not None
-        else (0.95, 1.05),
-        augment_space_prob=getattr(space_cfg, 'prob', 0.0),
-        augment_space_range=tuple(getattr(space_cfg, 'range', (0.90, 1.10)))
-        if space_cfg is not None
-        else (0.90, 1.10),
-        augment_freq_prob=getattr(freq_cfg, 'prob', 0.0),
-        augment_freq_kinds=tuple(getattr(freq_cfg, 'kinds', ()))
-        if freq_cfg is not None
-        else tuple(),
-        augment_freq_band=tuple(getattr(freq_cfg, 'band', (0.05, 0.45)))
-        if freq_cfg is not None
-        else (0.05, 0.45),
-        augment_freq_width=tuple(getattr(freq_cfg, 'width', (0.10, 0.35)))
-        if freq_cfg is not None
-        else (0.10, 0.35),
-        augment_freq_roll=getattr(freq_cfg, 'roll', 0.02) if freq_cfg is not None else 0.02,
-        augment_freq_restandardize=getattr(freq_cfg, 'restandardize', True)
-        if freq_cfg is not None
-        else True,
-        reject_fblc=getattr(dataset_cfg, 'reject_fblc', False),
-        fblc_percentile=getattr(dataset_cfg, 'fblc_percentile', 95.0),
-        fblc_thresh_ms=getattr(dataset_cfg, 'fblc_thresh_ms', 8.0),
-        fblc_min_pairs=getattr(dataset_cfg, 'fblc_min_pairs', 16),
-        fblc_apply_on=getattr(dataset_cfg, 'fblc_apply_on', 'any'),
-        valid=False,
-    )
+	dataset_cfg = getattr(cfg, 'dataset', object())
+	augment_cfg = getattr(dataset_cfg, 'augment', None)
+	time_cfg = getattr(augment_cfg, 'time', None) if augment_cfg is not None else None
+	space_cfg = getattr(augment_cfg, 'space', None) if augment_cfg is not None else None
+	freq_cfg = getattr(augment_cfg, 'freq', None) if augment_cfg is not None else None
+	return MaskedSegyGather(
+		[str(p) for p in segy_files],
+		[str(p) for p in fb_files],
+		primary_keys=getattr(dataset_cfg, 'primary_keys', None),
+		primary_key_weights=getattr(dataset_cfg, 'primary_key_weights', None),
+		use_header_cache=getattr(dataset_cfg, 'use_header_cache', False),
+		header_cache_dir=getattr(dataset_cfg, 'header_cache_dir', None),
+		use_superwindow=getattr(dataset_cfg, 'use_superwindow', False),
+		sw_halfspan=getattr(dataset_cfg, 'sw_halfspan', 0),
+		sw_prob=getattr(dataset_cfg, 'sw_prob', 0.3),
+		mask_ratio=getattr(dataset_cfg, 'mask_ratio', 0.0),
+		mask_mode=getattr(dataset_cfg, 'mask_mode', 'replace'),
+		mask_noise_std=getattr(dataset_cfg, 'mask_noise_std', 1.0),
+		target_mode=getattr(dataset_cfg, 'target_mode', 'recon'),
+		label_sigma=getattr(dataset_cfg, 'label_sigma', 1.0),
+		flip=getattr(dataset_cfg, 'flip', False),
+		augment_time_prob=getattr(time_cfg, 'prob', 0.0),
+		augment_time_range=tuple(getattr(time_cfg, 'range', (0.95, 1.05)))
+		if time_cfg is not None
+		else (0.95, 1.05),
+		augment_space_prob=getattr(space_cfg, 'prob', 0.0),
+		augment_space_range=tuple(getattr(space_cfg, 'range', (0.90, 1.10)))
+		if space_cfg is not None
+		else (0.90, 1.10),
+		augment_freq_prob=getattr(freq_cfg, 'prob', 0.0),
+		augment_freq_kinds=tuple(getattr(freq_cfg, 'kinds', ()))
+		if freq_cfg is not None
+		else tuple(),
+		augment_freq_band=tuple(getattr(freq_cfg, 'band', (0.05, 0.45)))
+		if freq_cfg is not None
+		else (0.05, 0.45),
+		augment_freq_width=tuple(getattr(freq_cfg, 'width', (0.10, 0.35)))
+		if freq_cfg is not None
+		else (0.10, 0.35),
+		augment_freq_roll=getattr(freq_cfg, 'roll', 0.02)
+		if freq_cfg is not None
+		else 0.02,
+		augment_freq_restandardize=getattr(freq_cfg, 'restandardize', True)
+		if freq_cfg is not None
+		else True,
+		reject_fblc=getattr(dataset_cfg, 'reject_fblc', False),
+		fblc_percentile=getattr(dataset_cfg, 'fblc_percentile', 95.0),
+		fblc_thresh_ms=getattr(dataset_cfg, 'fblc_thresh_ms', 8.0),
+		fblc_min_pairs=getattr(dataset_cfg, 'fblc_min_pairs', 16),
+		fblc_apply_on=getattr(dataset_cfg, 'fblc_apply_on', 'any'),
+		valid=False,
+	)
 
 
 def compute_norm_stats(
-    cfg,
-    *,
-    data_root: str,
-    train_field_list: str,
+	cfg,
+	*,
+	data_root: str,
+	train_field_list: str,
 ) -> tuple[float, float]:
-    """Compute the 95th percentile statistics for offsets and record lengths."""
+	"""Compute the 95th percentile statistics for offsets and record lengths."""
+	dataset = _build_train_dataset(
+		cfg, data_root=data_root, field_list=train_field_list
+	)
+	try:
+		all_offsets: list[np.ndarray] = []
+		all_tend_ms: list[float] = []
 
-    dataset = _build_train_dataset(cfg, data_root=data_root, field_list=train_field_list)
-    try:
-        all_offsets: list[np.ndarray] = []
-        all_tend_ms: list[float] = []
+		for info in dataset.file_infos:
+			offsets = np.asarray(info.get('offsets', []), dtype=np.float64)
+			if offsets.size:
+				all_offsets.append(offsets)
 
-        for info in dataset.file_infos:
-            offsets = np.asarray(info.get('offsets', []), dtype=np.float64)
-            if offsets.size:
-                all_offsets.append(offsets)
+			n_samples = int(info.get('n_samples', 0))
+			dt_sec = float(info.get('dt_sec', 0.0))
+			all_tend_ms.append(n_samples * dt_sec * 1000.0)
 
-            n_samples = int(info.get('n_samples', 0))
-            dt_sec = float(info.get('dt_sec', 0.0))
-            all_tend_ms.append(n_samples * dt_sec * 1000.0)
+		if not all_offsets:
+			raise RuntimeError('No offsets collected from training dataset.')
 
-        if not all_offsets:
-            raise RuntimeError('No offsets collected from training dataset.')
-
-        offsets_concat = np.concatenate(all_offsets)
-        x95_m = float(np.percentile(offsets_concat, 95))
-        t95_ms = float(np.percentile(np.asarray(all_tend_ms, dtype=np.float64), 95))
-        return x95_m, t95_ms
-    finally:
-        dataset.close()
+		offsets_concat = np.concatenate(all_offsets)
+		x95_m = float(np.percentile(offsets_concat, 95))
+		t95_ms = float(np.percentile(np.asarray(all_tend_ms, dtype=np.float64), 95))
+		return x95_m, t95_ms
+	finally:
+		dataset.close()
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description='Compute robust normalization statistics from the training split.'
-    )
-    parser.add_argument(
-        '--data_root',
-        type=str,
-        default=None,
-        help='Override the dataset root directory (defaults to cfg.data_root).',
-    )
-    parser.add_argument(
-        '--train_field_list',
-        type=str,
-        default=None,
-        help='Override the training field list file (defaults to cfg.train_field_list).',
-    )
-    return parser.parse_args()
+	parser = argparse.ArgumentParser(
+		description='Compute robust normalization statistics from the training split.'
+	)
+	parser.add_argument(
+		'--data_root',
+		type=str,
+		default=None,
+		help='Override the dataset root directory (defaults to cfg.data_root).',
+	)
+	parser.add_argument(
+		'--train_field_list',
+		type=str,
+		default=None,
+		help='Override the training field list file (defaults to cfg.train_field_list).',
+	)
+	return parser.parse_args()
 
 
 def main() -> None:
-    args = parse_args()
+	args = parse_args()
 
-    with initialize(config_path='../configs', version_base='1.3'):
-        cfg = compose(config_name='base')
+	with initialize(config_path='../configs', version_base='1.3'):
+		cfg = compose(config_name='base')
 
-    data_root = args.data_root or cfg.data_root
-    train_field_list = args.train_field_list or cfg.train_field_list
+	data_root = args.data_root or cfg.data_root
+	train_field_list = args.train_field_list or cfg.train_field_list
 
-    x95_m, t95_ms = compute_norm_stats(
-        cfg,
-        data_root=data_root,
-        train_field_list=train_field_list,
-    )
+	x95_m, t95_ms = compute_norm_stats(
+		cfg,
+		data_root=data_root,
+		train_field_list=train_field_list,
+	)
 
-    print('norm:')
-    print(f'  x95_m: {x95_m:.4f}')
-    print(f'  t95_ms: {t95_ms:.4f}')
+	print('norm:')
+	print(f'  x95_m: {x95_m:.4f}')
+	print(f'  t95_ms: {t95_ms:.4f}')
 
 
 if __name__ == '__main__':
-    main()
-
+	main()

--- a/proc/train.py
+++ b/proc/train.py
@@ -26,7 +26,7 @@ from proc.util.ema import ModelEMA
 from proc.util.eval import eval_synthe, val_one_epoch_snr
 from proc.util.loss import make_criterion, make_fb_seg_criterion
 from proc.util.model import NetAE, adjust_first_conv_padding
-from proc.util.model_utils import inflate_input_convs_to_nch, inflate_input_convs_to_2ch
+from proc.util.model_utils import inflate_input_convs_to_2ch, inflate_input_convs_to_nch
 from proc.util.predict import cover_all_traces_predict_chunked
 from proc.util.rng_util import worker_init_fn
 from proc.util.train_loop import train_one_epoch
@@ -121,7 +121,7 @@ train_dataset = MaskedSegyGather(
 	fblc_thresh_ms=cfg.dataset.fblc_thresh_ms,
 	fblc_min_pairs=cfg.dataset.fblc_min_pairs,
 	fblc_apply_on=cfg.dataset.fblc_apply_on,
-	valid=False,
+	valid=True,
 )
 
 if task == 'fb_seg':
@@ -448,6 +448,7 @@ for epoch in range(cfg.start_epoch, epochs):
 		step=step,
 		freeze_epochs=cfg.freeze_epochs,
 		unfreeze_steps=cfg.unfreeze_steps,
+		cfg=cfg,
 	)
 	eval_model = ema.module if ema else model
 

--- a/proc/util/model_utils.py
+++ b/proc/util/model_utils.py
@@ -68,49 +68,11 @@ def _make_inflated_weight(
 		mean_w = old_w.mean(dim=1, keepdim=True)
 		chunks.append(mean_w.repeat(1, remainder, 1, 1))
 	if not chunks:
-		raise ValueError(
-			'target_in_ch must be >= old_in_ch when inflating weights'
-		)
-	new_w = (
-		torch.cat(chunks, dim=1)
-		if len(chunks) > 1
-		else chunks[0]
-	)
+		raise ValueError('target_in_ch must be >= old_in_ch when inflating weights')
+	new_w = torch.cat(chunks, dim=1) if len(chunks) > 1 else chunks[0]
 	scale = float(old_in_ch) / float(target_in_ch)
 	new_w = new_w * scale
 	return new_w
-
-def _inflate_conv_in_to_2(conv: nn.Conv2d, *, verbose: bool, init_mode: str) -> None:
-	"""Make conv.in_channels = 2 (keep out_channels)."""
-	if conv.in_channels == 2:
-		if verbose:
-			print(f'[inflate] keep in=2 for {conv}')
-		return
-	assert conv.in_channels == 1, f'in_channels must be 1 or 2, got {conv.in_channels}'
-	out_ch = conv.out_channels
-	new_conv = nn.Conv2d(
-		in_channels=2,
-		out_channels=out_ch,
-		kernel_size=conv.kernel_size,
-		stride=conv.stride,
-		padding=conv.padding,
-		dilation=conv.dilation,
-		groups=conv.groups,
-		bias=(conv.bias is not None),
-		padding_mode=conv.padding_mode,
-		device=conv.weight.device,
-		dtype=conv.weight.dtype,
-	)
-	with torch.no_grad():
-		new_conv.weight.copy_(_dup_or_init_like(conv.weight.data, out_ch, 2, init_mode))
-		if conv.bias is not None:
-			new_conv.bias.copy_(conv.bias.data)
-	# in-place swap
-	conv.weight = new_conv.weight
-	conv.bias = new_conv.bias
-	conv.in_channels = new_conv.in_channels
-	if verbose:
-		print(f'[inflate] {type(conv).__name__}: in 1→2')
 
 
 def _inflate_conv_in_channels(
@@ -128,14 +90,11 @@ def _inflate_conv_in_channels(
 		return False
 	if old_in > target_in_ch:
 		if verbose:
-			print(
-				f'[inflate][WARN] skip {name}: '
-				f'in={old_in} > target={target_in_ch}'
-			)
+			print(f'[inflate][WARN] skip {name}: in={old_in} > target={target_in_ch}')
 		return False
-	assert (
-		conv.groups == 1
-	), f'Cannot inflate grouped/depthwise convs (groups={conv.groups})'
+	assert conv.groups == 1, (
+		f'Cannot inflate grouped/depthwise convs (groups={conv.groups})'
+	)
 	new_weight = _make_inflated_weight(conv, target_in_ch, init_mode)
 	conv.in_channels = target_in_ch
 	conv.weight = nn.Parameter(new_weight)
@@ -144,43 +103,60 @@ def _inflate_conv_in_channels(
 	return True
 
 
-def _replace_seq_conv_bn_to_2x(
+def _rebuild_seq_first_conv_bn(
 	seq: nn.Sequential,
 	conv_idx: int,
 	bn_idx: int | None,
+	target_in_ch: int,
+	target_out_ch: int,
 	*,
 	verbose: bool,
 	init_mode: str,
+	name: str,
 ) -> None:
-	"""Replace seq[conv_idx] (Conv2d) to in=2,out=2 and BN to num_features=2."""
+	"""Rebuild seq[conv_idx] Conv2d (and BN if present) to (in=target_in_ch, out=target_out_ch).
+	- In-weights are inflated via duplicate+mean, keeping fan-in stable.
+	- Out-weights are sliced or Kaiming-inited to match target_out_ch.
+	"""
 	old_conv: nn.Conv2d = seq[conv_idx]
 	assert isinstance(old_conv, nn.Conv2d)
+	assert old_conv.groups == 1, (
+		f'Cannot rebuild grouped/depthwise convs (groups={old_conv.groups})'
+	)
+	device, dtype = old_conv.weight.device, old_conv.weight.dtype
+
 	new_conv = nn.Conv2d(
-		in_channels=2,
-		out_channels=2,
+		in_channels=target_in_ch,
+		out_channels=target_out_ch,
 		kernel_size=old_conv.kernel_size,
 		stride=old_conv.stride,
 		padding=old_conv.padding,
 		dilation=old_conv.dilation,
-		groups=old_conv.groups,
+		groups=1,
 		bias=(old_conv.bias is not None),
 		padding_mode=old_conv.padding_mode,
-		device=old_conv.weight.device,
-		dtype=old_conv.weight.dtype,
+		device=device,
+		dtype=dtype,
 	)
 	with torch.no_grad():
-		new_conv.weight.copy_(_dup_or_init_like(old_conv.weight.data, 2, 2, init_mode))
+		w_infl = _make_inflated_weight(old_conv, target_in_ch, init_mode)
+		O_old, _, kH, kW = w_infl.shape
+		if target_out_ch <= O_old:
+			new_w = w_infl[:target_out_ch]
+		else:
+			extra = torch.empty(
+				(target_out_ch - O_old, target_in_ch, kH, kW),
+				device=device,
+				dtype=dtype,
+			)
+			nn.init.kaiming_normal_(extra, nonlinearity='relu')
+			new_w = torch.cat([w_infl, extra], dim=0)
+		new_conv.weight.copy_(new_w)
 		if old_conv.bias is not None:
-			# duplicate bias if needed
-			b = old_conv.bias.data
-			if b.numel() == 1:
-				new_conv.bias.copy_(b.expand(2))
-			else:
-				new_conv.bias.copy_(b[:2])
-
+			new_conv.bias.zero_()
+			n = min(target_out_ch, old_conv.bias.numel())
+			new_conv.bias[:n].copy_(old_conv.bias[:n])
 	seq[conv_idx] = new_conv
-	if verbose:
-		print(f'[inflate] {seq.__class__.__name__}[{conv_idx}]: (in,out) → (2,2)')
 
 	if (
 		bn_idx is not None
@@ -189,116 +165,26 @@ def _replace_seq_conv_bn_to_2x(
 	):
 		old_bn = seq[bn_idx]
 		new_bn = type(old_bn)(
-			2,
+			target_out_ch,
 			eps=old_bn.eps,
 			momentum=old_bn.momentum,
 			affine=old_bn.affine,
 			track_running_stats=old_bn.track_running_stats,
-			device=old_bn.weight.device,
-			dtype=old_bn.weight.dtype,
+			device=device,
+			dtype=dtype,
 		)
 		with torch.no_grad():
 			if old_bn.affine:
-				w = old_bn.weight.data
-				b = old_bn.bias.data
-				if w.numel() == 1:
-					new_bn.weight.copy_(w.expand(2))
-					new_bn.bias.copy_(b.expand(2))
-				else:
-					new_bn.weight.copy_(w[:2])
-					new_bn.bias.copy_(b[:2])
+				n = min(target_out_ch, old_bn.weight.numel())
+				new_bn.weight[:n].copy_(old_bn.weight[:n])
+				new_bn.bias[:n].copy_(old_bn.bias[:n])
 			if old_bn.track_running_stats:
-				rm = old_bn.running_mean
-				rv = old_bn.running_var
-				if rm.numel() == 1:
-					new_bn.running_mean.copy_(rm.expand(2))
-					new_bn.running_var.copy_(rv.expand(2))
-				else:
-					new_bn.running_mean.copy_(rm[:2])
-					new_bn.running_var.copy_(rv[:2])
+				n = min(target_out_ch, old_bn.running_mean.numel())
+				new_bn.running_mean[:n].copy_(old_bn.running_mean[:n])
+				new_bn.running_var[:n].copy_(old_bn.running_var[:n])
 		seq[bn_idx] = new_bn
-		if verbose:
-			print(f'[inflate] {seq.__class__.__name__}[{bn_idx}]: BN channels → 2')
-
-
-def _rebuild_seq_first_conv_bn(
-        seq: nn.Sequential,
-        conv_idx: int,
-        bn_idx: int | None,
-        target_in_ch: int,
-        target_out_ch: int,
-        *,
-        verbose: bool,
-        init_mode: str,
-        name: str,
-) -> None:
-        """Rebuild seq[conv_idx] Conv2d (and BN if present) to (in=target_in_ch, out=target_out_ch).
-        - In-weights are inflated via duplicate+mean, keeping fan-in stable.
-        - Out-weights are sliced or Kaiming-inited to match target_out_ch.
-        """
-        old_conv: nn.Conv2d = seq[conv_idx]
-        assert isinstance(old_conv, nn.Conv2d)
-        assert (
-                old_conv.groups == 1
-        ), f'Cannot rebuild grouped/depthwise convs (groups={old_conv.groups})'
-        device, dtype = old_conv.weight.device, old_conv.weight.dtype
-
-        new_conv = nn.Conv2d(
-                in_channels=target_in_ch,
-                out_channels=target_out_ch,
-                kernel_size=old_conv.kernel_size,
-                stride=old_conv.stride,
-                padding=old_conv.padding,
-                dilation=old_conv.dilation,
-                groups=1,
-                bias=(old_conv.bias is not None),
-                padding_mode=old_conv.padding_mode,
-                device=device,
-                dtype=dtype,
-        )
-        with torch.no_grad():
-                w_infl = _make_inflated_weight(old_conv, target_in_ch, init_mode)
-                O_old, _, kH, kW = w_infl.shape
-                if target_out_ch <= O_old:
-                        new_w = w_infl[:target_out_ch]
-                else:
-                        extra = torch.empty((target_out_ch - O_old, target_in_ch, kH, kW), device=device, dtype=dtype)
-                        nn.init.kaiming_normal_(extra, nonlinearity='relu')
-                        new_w = torch.cat([w_infl, extra], dim=0)
-                new_conv.weight.copy_(new_w)
-                if old_conv.bias is not None:
-                        new_conv.bias.zero_()
-                        n = min(target_out_ch, old_conv.bias.numel())
-                        new_conv.bias[:n].copy_(old_conv.bias[:n])
-        seq[conv_idx] = new_conv
-
-        if (
-                bn_idx is not None
-                and 0 <= bn_idx < len(seq)
-                and isinstance(seq[bn_idx], (nn.BatchNorm2d, nn.SyncBatchNorm))
-        ):
-                old_bn = seq[bn_idx]
-                new_bn = type(old_bn)(
-                        target_out_ch,
-                        eps=old_bn.eps,
-                        momentum=old_bn.momentum,
-                        affine=old_bn.affine,
-                        track_running_stats=old_bn.track_running_stats,
-                        device=device,
-                        dtype=dtype,
-                )
-                with torch.no_grad():
-                        if old_bn.affine:
-                                n = min(target_out_ch, old_bn.weight.numel())
-                                new_bn.weight[:n].copy_(old_bn.weight[:n])
-                                new_bn.bias[:n].copy_(old_bn.bias[:n])
-                        if old_bn.track_running_stats:
-                                n = min(target_out_ch, old_bn.running_mean.numel())
-                                new_bn.running_mean[:n].copy_(old_bn.running_mean[:n])
-                                new_bn.running_var[:n].copy_(old_bn.running_var[:n])
-                seq[bn_idx] = new_bn
-        if verbose:
-                print(f"[inflate] {name}: rebuilt to (in={target_in_ch}, out={target_out_ch})")
+	if verbose:
+		print(f'[inflate] {name}: rebuilt to (in={target_in_ch}, out={target_out_ch})')
 
 
 def inflate_input_convs_to_nch(
@@ -353,7 +239,10 @@ def inflate_input_convs_to_nch(
 				for idx, sub in enumerate(seq):
 					if isinstance(sub, nn.Conv2d) and first_conv_idx is None:
 						first_conv_idx = idx
-					if isinstance(sub, nn.BatchNorm2d) and first_bn_idx is None:
+					if (
+						isinstance(sub, (nn.BatchNorm2d, nn.SyncBatchNorm))
+						and first_bn_idx is None
+					):
 						first_bn_idx = idx
 				if first_conv_idx is not None:
 					if blk_idx == 0 and tie_predown0_out_to_in:
@@ -383,6 +272,35 @@ def inflate_input_convs_to_nch(
 								f'[inflate] pre_down[{blk_idx}]: already '
 								f'in/out={target_in_ch}'
 							)
+					elif blk_idx == 1:
+						# ★ ここがキモ：pre_down[1] の出力を target_in_ch に必ず合わせる
+						conv1: nn.Conv2d = seq[first_conv_idx]
+						needs_rebuild = (
+							conv1.in_channels != target_in_ch
+							or conv1.out_channels != target_in_ch
+						)
+						if needs_rebuild:
+							if (
+								hasattr(conv1, '_grad_mask_handle')
+								and conv1._grad_mask_handle is not None
+							):
+								_remove_grad_mask(conv1)
+							_rebuild_seq_first_conv_bn(
+								seq,
+								first_conv_idx,
+								first_bn_idx,
+								target_in_ch,
+								target_in_ch,
+								verbose=verbose,
+								init_mode=init_mode,
+								name=f'pre_down[{blk_idx}]',
+							)
+						elif verbose:
+							print(
+								f'[inflate] pre_down[{blk_idx}]: already '
+								f'in/out={target_in_ch}'
+							)
+
 					else:
 						name = f'pre_down[{blk_idx}][{first_conv_idx}]'
 						_maybe_inflate(seq[first_conv_idx], name)
@@ -410,6 +328,7 @@ def inflate_input_convs_to_nch(
 
 	if verbose:
 		print('[inflate] done.')
+
 
 def inflate_input_convs_to_2ch(
 	model: nn.Module,

--- a/proc/util/train_loop.py
+++ b/proc/util/train_loop.py
@@ -107,17 +107,17 @@ def train_one_epoch(
 	device,
 	epoch,
 	print_freq,
-        writer=None,
-        use_offset_input: bool = False,
-        use_amp=True,
-        scaler=None,
-        ema=None,
-        gradient_accumulation_steps=1,
-        max_shift=5,
-        step: int = 0,
-        freeze_epochs: int = 0,
-        unfreeze_steps: int = 1,
-        cfg=None,
+	writer=None,
+	use_offset_input: bool = False,
+	use_amp=True,
+	scaler=None,
+	ema=None,
+	gradient_accumulation_steps=1,
+	max_shift=5,
+	step: int = 0,
+	freeze_epochs: int = 0,
+	unfreeze_steps: int = 1,
+	cfg=None,
 ):
 	"""Run one training epoch."""
 	if getattr(model, '_transfer_loaded', False) and freeze_epochs > 0:
@@ -204,6 +204,7 @@ def train_one_epoch(
 			with autocast(device_type=device_type, enabled=use_amp):
 				x_in = x_masked
 				cfg_obj = cfg if cfg is not None else getattr(model, 'cfg', None)
+
 				if (
 					use_offset_input
 					and cfg_obj is not None
@@ -228,14 +229,14 @@ def train_one_epoch(
 					offs_ch = make_offset_channel_phys(
 						x_masked,
 						meta['offsets'],
-						x95_m=getattr(norm_cfg, 'x95_m'),
+						x95_m=norm_cfg.x95_m,
 						mode=getattr(norm_cfg, 'offset_mode', 'log1p'),
 						clip_hi=getattr(norm_cfg, 'offset_clip_hi', 1.5),
 					)
 					time_ch = make_time_channel(
 						x_masked,
 						meta['dt_sec'],
-						t95_ms=getattr(norm_cfg, 't95_ms'),
+						t95_ms=norm_cfg.t95_ms,
 						clip_hi=getattr(norm_cfg, 'time_clip_hi', 1.5),
 					)
 					x_in = torch.cat([x_masked, offs_ch, time_ch], dim=1)


### PR DESCRIPTION
## Summary
- add a debug helper that mirrors the training dataset construction
- compute robust 95th percentile offsets and record lengths from the train split
- print the resulting YAML snippet for easy copy/paste into configs

## Testing
- `python proc/debug/compute_norm_stats.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68cd3a6554c4832b8cfcc26f191396d6