### PR TITLE
Support offset input during evaluation and chunked prediction

### DIFF
--- a/proc/util/eval.py
+++ b/proc/util/eval.py
@@ -21,6 +21,7 @@ def val_one_epoch_snr(
 	writer=None,
 	epoch: int | None = None,
 	is_main_process: bool = True,
+	use_offset_input: bool = False,
 ):
 	"""Evaluate SNR improvement over validation loader."""
 	import matplotlib.pyplot as plt
@@ -30,6 +31,11 @@ def val_one_epoch_snr(
 	for i, (x_masked, x_orig, _, meta) in enumerate(val_loader):
 		x_orig = x_orig.to(device, non_blocking=True)
 		fb_idx = meta['fb_idx'].to(device)
+		offsets = None
+		if use_offset_input:
+			if 'offsets' not in meta:
+				raise KeyError('offsets field is required when use_offset_input=True')
+			offsets = meta['offsets']
 		y_full = cover_all_traces_predict(
 			model,
 			x_orig,
@@ -40,6 +46,8 @@ def val_one_epoch_snr(
 			seed=cfg_snr.seed,
 			passes_batch=cfg_snr.passes_batch,
 			mask_noise_mode=getattr(cfg_snr, 'mask_noise_mode', 'replace'),
+			use_offset_input=use_offset_input,
+			offsets=offsets,
 		)
 		cache = prepare_fb_windows(
 			fb_idx,


### PR DESCRIPTION
## Summary
- extend cover_all_traces_predict and its chunked variant to build static offset channels when required by the model
- propagate offset metadata through val_one_epoch_snr so evaluation works with two-channel inputs
- prepare synthetic offset tensors for chunked prediction during recon validation when offset inputs are enabled

## Testing
- python -m compileall proc/util/predict.py proc/util/eval.py proc/train.py

------
https://chatgpt.com/codex/tasks/task_e_68d5f32927d0832b8bed6a858a1ba82b