### PR TITLE
refactor(dataset): extract TraceMasker (replace/add) and integrate into MaskedSegyGather

### DIFF
--- a/proc/util/datasets/masked_segy_gather.py
+++ b/proc/util/datasets/masked_segy_gather.py
@@ -11,12 +11,13 @@ from scipy.signal import resample_poly
 from torch.utils.data import Dataset
 
 from proc.util.augment import (
-	_apply_freq_augment,
-	_spatial_stretch_sameH,
+        _apply_freq_augment,
+        _spatial_stretch_sameH,
 )
 from proc.util.datasets.config import LoaderConfig, TraceSubsetSamplerConfig
 from proc.util.datasets.trace_subset_preproc import TraceSubsetLoader
 from proc.util.datasets.trace_subset_sampler import TraceSubsetSampler
+from .trace_masker import TraceMasker, TraceMaskerConfig
 
 __all__ = ['MaskedSegyGather']
 
@@ -193,11 +194,18 @@ class MaskedSegyGather(Dataset):
 		self.use_header_cache = use_header_cache
 		self.header_cache_dir = header_cache_dir
 
-		self.mask_ratio = mask_ratio
-		self.mask_mode = mask_mode
-		self.mask_noise_std = mask_noise_std
-		self.flip = flip
-		self.pick_ratio = pick_ratio
+                self.mask_ratio = mask_ratio
+                self.mask_mode = mask_mode
+                self.mask_noise_std = mask_noise_std
+                self.masker = TraceMasker(
+                        TraceMaskerConfig(
+                                mask_ratio=self.mask_ratio,
+                                mode=self.mask_mode,
+                                noise_std=self.mask_noise_std,
+                        )
+                )
+                self.flip = flip
+                self.pick_ratio = pick_ratio
 		self.target_len = target_len
 		self.augment_time_prob = augment_time_prob
 		self.augment_time_range = augment_time_range
@@ -571,21 +579,8 @@ class MaskedSegyGather(Dataset):
 							f'for FBLC {p_ms:.1f}ms <= {self.fblc_thresh_ms}ms'
 						)
 
-			# masking (after acceptance)
-			H = x.shape[0]
-			num_mask = int(self.mask_ratio * H)
-			mask_idx = random.sample(range(H), num_mask) if num_mask > 0 else []
-			x_masked = x.copy()
-			if num_mask > 0:
-				noise = np.random.normal(
-					0.0, self.mask_noise_std, size=(num_mask, x.shape[1])
-				)
-				if self.mask_mode == 'replace':
-					x_masked[mask_idx] = noise
-				elif self.mask_mode == 'add':
-					x_masked[mask_idx] += noise
-				else:
-					raise ValueError(f'Invalid mask_mode: {self.mask_mode}')
+                        # masking (after acceptance)
+                        x_masked, mask_idx = self.masker.apply(x, py_random=random)
 
 			# target (optional)
 			target_t = None

--- a/proc/util/datasets/masked_segy_gather.py
+++ b/proc/util/datasets/masked_segy_gather.py
@@ -11,12 +11,13 @@ from scipy.signal import resample_poly
 from torch.utils.data import Dataset
 
 from proc.util.augment import (
-        _apply_freq_augment,
-        _spatial_stretch_sameH,
+	_apply_freq_augment,
+	_spatial_stretch_sameH,
 )
 from proc.util.datasets.config import LoaderConfig, TraceSubsetSamplerConfig
 from proc.util.datasets.trace_subset_preproc import TraceSubsetLoader
 from proc.util.datasets.trace_subset_sampler import TraceSubsetSampler
+
 from .trace_masker import TraceMasker, TraceMaskerConfig
 
 __all__ = ['MaskedSegyGather']
@@ -194,18 +195,18 @@ class MaskedSegyGather(Dataset):
 		self.use_header_cache = use_header_cache
 		self.header_cache_dir = header_cache_dir
 
-                self.mask_ratio = mask_ratio
-                self.mask_mode = mask_mode
-                self.mask_noise_std = mask_noise_std
-                self.masker = TraceMasker(
-                        TraceMaskerConfig(
-                                mask_ratio=self.mask_ratio,
-                                mode=self.mask_mode,
-                                noise_std=self.mask_noise_std,
-                        )
-                )
-                self.flip = flip
-                self.pick_ratio = pick_ratio
+		self.mask_ratio = mask_ratio
+		self.mask_mode = mask_mode
+		self.mask_noise_std = mask_noise_std
+		self.masker = TraceMasker(
+			TraceMaskerConfig(
+				mask_ratio=self.mask_ratio,
+				mode=self.mask_mode,
+				noise_std=self.mask_noise_std,
+			)
+		)
+		self.flip = flip
+		self.pick_ratio = pick_ratio
 		self.target_len = target_len
 		self.augment_time_prob = augment_time_prob
 		self.augment_time_range = augment_time_range
@@ -579,8 +580,8 @@ class MaskedSegyGather(Dataset):
 							f'for FBLC {p_ms:.1f}ms <= {self.fblc_thresh_ms}ms'
 						)
 
-                        # masking (after acceptance)
-                        x_masked, mask_idx = self.masker.apply(x, py_random=random)
+						# masking (after acceptance)
+						x_masked, mask_idx = self.masker.apply(x, py_random=random)
 
 			# target (optional)
 			target_t = None

--- a/proc/util/datasets/masked_segy_gather.py
+++ b/proc/util/datasets/masked_segy_gather.py
@@ -580,8 +580,14 @@ class MaskedSegyGather(Dataset):
 							f'for FBLC {p_ms:.1f}ms <= {self.fblc_thresh_ms}ms'
 						)
 
-						# masking (after acceptance)
-						x_masked, mask_idx = self.masker.apply(x, py_random=random)
+			# masking (after acceptance)
+			x_masked, mask_idx = self.masker.apply(
+				x,
+				mask_ratio=self.mask_ratio,
+				mode=self.mask_mode,
+				noise_std=self.mask_noise_std,
+				py_random=random,
+			)
 
 			# target (optional)
 			target_t = None

--- a/proc/util/datasets/trace_masker.py
+++ b/proc/util/datasets/trace_masker.py
@@ -1,60 +1,71 @@
 from __future__ import annotations
 
+import random
 from dataclasses import dataclass
 from typing import Literal
-import random
 
 import numpy as np
 
-MaskMode = Literal["replace", "add"]
+MaskMode = Literal['replace', 'add']
 
 
 @dataclass(frozen=True)
 class TraceMaskerConfig:
-        mask_ratio: float = 0.5  # [0,1]
-        mode: MaskMode = "replace"  # "replace" or "add"
-        noise_std: float = 1.0  # Gaussian std
+	mask_ratio: float = 0.5  # [0,1]
+	mode: MaskMode = 'replace'  # "replace" or "add"
+	noise_std: float = 1.0  # Gaussian std
 
 
 class TraceMasker:
-        """
-        Apply masking to an (H, T) float32 array x.
-        Picks int(mask_ratio*H) trace indices via random.sample,
-        and either REPLACE those traces with noise or ADD noise.
-        Returns (x_masked, mask_indices).
-        """
+	"""Apply masking to an (H, T) float32 array x.
+	Picks int(mask_ratio*H) trace indices via random.sample,
+	and either REPLACE those traces with noise or ADD noise.
+	Returns (x_masked, mask_indices).
+	"""
 
-        def __init__(self, cfg: TraceMaskerConfig):
-                if not (0.0 <= cfg.mask_ratio <= 1.0):
-                        raise ValueError("mask_ratio must be in [0,1]")
-                if cfg.mode not in ("replace", "add"):
-                        raise ValueError(f"invalid mode: {cfg.mode}")
-                if cfg.noise_std < 0:
-                        raise ValueError("noise_std must be >= 0")
-                self.cfg = cfg
+	def __init__(self, cfg: TraceMaskerConfig):
+		if not (0.0 <= cfg.mask_ratio <= 1.0):
+			raise ValueError('mask_ratio must be in [0,1]')
+		if cfg.mode not in ('replace', 'add'):
+			raise ValueError(f'invalid mode: {cfg.mode}')
+		if cfg.noise_std < 0:
+			raise ValueError('noise_std must be >= 0')
+		self.cfg = cfg
 
-        def apply(
-                self,
-                x: np.ndarray,  # shape (H, T), float32 expected
-                *,
-                py_random: random.Random | None = None,
-        ) -> tuple[np.ndarray, list[int]]:
-                if x.ndim != 2:
-                        raise ValueError(f"x must be 2D (H,T), got {x.shape}")
-                H, T = x.shape
-                num_mask = int(self.cfg.mask_ratio * H)
-                if num_mask <= 0:
-                        return x.copy(), []  # keep original but return a copy
+	def apply(
+		self,
+		x: np.ndarray,
+		*,
+		mask_ratio: float | None = None,
+		mode: Literal['replace', 'add'] | None = None,
+		noise_std: float | None = None,
+		py_random: random.Random | None = None,
+	):
+		ratio = self.cfg.mask_ratio if mask_ratio is None else float(mask_ratio)
+		md = self.cfg.mode if mode is None else mode
+		std = self.cfg.noise_std if noise_std is None else float(noise_std)
+		if not (0.0 <= ratio <= 1.0):
+			raise ValueError('mask_ratio must be in [0,1]')
+		if md not in ('replace', 'add'):
+			raise ValueError(f'invalid mode: {md}')
+		if std < 0:
+			raise ValueError('noise_std must be >= 0')
+		if x.ndim != 2:
+			raise ValueError(f'x must be 2D (H,T), got {x.shape}')
+		H, T = x.shape
+		num_mask = int(self.cfg.mask_ratio * H)
+		if num_mask <= 0:
+			return x.copy(), []  # keep original but return a copy
 
-                r = py_random or random
-                mask_idx = r.sample(range(H), num_mask)  # matches legacy behavior
+		r = py_random or random
+		mask_idx = r.sample(range(H), num_mask)  # matches legacy behavior
 
-                x_masked = x.copy()
-                noise = np.random.normal(0.0, self.cfg.noise_std, size=(num_mask, T)).astype(
-                        np.float32
-                )
-                if self.cfg.mode == "replace":
-                        x_masked[mask_idx] = noise
-                else:  # "add"
-                        x_masked[mask_idx] += noise
-                return x_masked, mask_idx
+		x_masked = x.copy()
+		noise = np.random.normal(0.0, self.cfg.noise_std, size=(num_mask, T)).astype(
+			np.float32
+		)
+		if self.cfg.mode == 'replace':
+			x_masked[mask_idx] = noise
+		else:  # "add"
+			x_masked[mask_idx] += noise
+		return x_masked, mask_idx

--- a/proc/util/datasets/trace_masker.py
+++ b/proc/util/datasets/trace_masker.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+import random
+
+import numpy as np
+
+MaskMode = Literal["replace", "add"]
+
+
+@dataclass(frozen=True)
+class TraceMaskerConfig:
+        mask_ratio: float = 0.5  # [0,1]
+        mode: MaskMode = "replace"  # "replace" or "add"
+        noise_std: float = 1.0  # Gaussian std
+
+
+class TraceMasker:
+        """
+        Apply masking to an (H, T) float32 array x.
+        Picks int(mask_ratio*H) trace indices via random.sample,
+        and either REPLACE those traces with noise or ADD noise.
+        Returns (x_masked, mask_indices).
+        """
+
+        def __init__(self, cfg: TraceMaskerConfig):
+                if not (0.0 <= cfg.mask_ratio <= 1.0):
+                        raise ValueError("mask_ratio must be in [0,1]")
+                if cfg.mode not in ("replace", "add"):
+                        raise ValueError(f"invalid mode: {cfg.mode}")
+                if cfg.noise_std < 0:
+                        raise ValueError("noise_std must be >= 0")
+                self.cfg = cfg
+
+        def apply(
+                self,
+                x: np.ndarray,  # shape (H, T), float32 expected
+                *,
+                py_random: random.Random | None = None,
+        ) -> tuple[np.ndarray, list[int]]:
+                if x.ndim != 2:
+                        raise ValueError(f"x must be 2D (H,T), got {x.shape}")
+                H, T = x.shape
+                num_mask = int(self.cfg.mask_ratio * H)
+                if num_mask <= 0:
+                        return x.copy(), []  # keep original but return a copy
+
+                r = py_random or random
+                mask_idx = r.sample(range(H), num_mask)  # matches legacy behavior
+
+                x_masked = x.copy()
+                noise = np.random.normal(0.0, self.cfg.noise_std, size=(num_mask, T)).astype(
+                        np.float32
+                )
+                if self.cfg.mode == "replace":
+                        x_masked[mask_idx] = noise
+                else:  # "add"
+                        x_masked[mask_idx] += noise
+                return x_masked, mask_idx

--- a/tests/test_mask_runtime_update.py
+++ b/tests/test_mask_runtime_update.py
@@ -1,0 +1,76 @@
+import os
+
+import numpy as np
+import pytest
+import torch
+
+from proc.util.datasets.masked_segy_gather import MaskedSegyGather
+
+SEGY = os.getenv('FBP_TEST_SEGY')  # 例: /path/to/data.sgy
+FBNP = os.getenv('FBP_TEST_FB')  # 例: /path/to/data_fb.npy
+
+pytestmark = pytest.mark.skipif(
+	not (SEGY and FBNP),
+	reason='Set FBP_TEST_SEGY and FBP_TEST_FB to run this test.',
+)
+
+
+def _build_ds(mask_ratio: float) -> MaskedSegyGather:
+	return MaskedSegyGather(
+		segy_files=[SEGY],
+		fb_files=[FBNP],
+		# ランダム性・再抽選を抑える（仕様テスト向け）
+		use_superwindow=False,
+		augment_time_prob=0.0,
+		augment_space_prob=0.0,
+		augment_freq_prob=0.0,
+		flip=False,
+		pick_ratio=0.0,
+		reject_fblc=False,
+		valid=True,
+		verbose=False,
+		mask_ratio=mask_ratio,
+		mask_mode='replace',
+		mask_noise_std=1.0,
+	)
+
+
+def test_mask_ratio_runtime_update_changes_mask_count():
+	ds = _build_ds(mask_ratio=0.0)
+
+	# 1st: マスク無効
+	a = ds[None]
+	Ha = a['original'].shape[1]
+	assert isinstance(a['masked'], torch.Tensor)
+	assert len(a['mask_indices']) == 0
+
+	# 2nd: ランタイムに 50% へ更新 → 本数が変わる
+	ds.mask_ratio = 0.5
+	b = ds[None]
+	Hb = b['original'].shape[1]
+	assert len(b['mask_indices']) == int(0.5 * Hb)
+
+	ds.close()
+
+
+def test_mask_mode_and_noise_runtime_update_effect():
+	ds = _build_ds(mask_ratio=0.5)
+
+	# まず replace: 値が変わる（高確率）
+	x1 = ds[None]
+	assert len(x1['mask_indices']) == int(0.5 * x1['original'].shape[1])
+	# runtime で "add" & noise_std=0.0 → 値は変わらないはず
+	ds.mask_mode = 'add'
+	ds.mask_noise_std = 0.0
+	x2 = ds[None]
+	# 形・本数はそのまま
+	assert len(x2['mask_indices']) == int(0.5 * x2['original'].shape[1])
+	# 追加ノイズが0なので masked == original
+	np.testing.assert_allclose(
+		x2['masked'].cpu().numpy(),
+		x2['original'].cpu().numpy(),
+		atol=0.0,
+		rtol=0.0,
+	)
+
+	ds.close()

--- a/tests/test_trace_masker_semantics.py
+++ b/tests/test_trace_masker_semantics.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from proc.util.datasets.trace_masker import TraceMasker, TraceMaskerConfig
+
+
+def test_trace_masker_semantics_replace():
+        H, T = 8, 16
+        x = np.random.randn(H, T).astype(np.float32)
+        m = TraceMasker(TraceMaskerConfig(mask_ratio=0.25, mode="replace", noise_std=1.0))
+        xm, idx = m.apply(x)
+        assert xm.shape == x.shape and xm.dtype == np.float32
+        assert len(idx) == int(0.25 * H)
+        keep = np.ones(H, dtype=bool)
+        keep[idx] = False
+        assert np.allclose(xm[keep], x[keep])  # untouched rows are identical
+
+
+def test_trace_masker_semantics_add():
+        H, T = 8, 16
+        x = np.zeros((H, T), dtype=np.float32)
+        m = TraceMasker(TraceMaskerConfig(mask_ratio=0.5, mode="add", noise_std=0.5))
+        xm, idx = m.apply(x)
+        assert xm.shape == x.shape
+        # masked rows should be non-zero with high probability
+        assert (np.abs(xm[idx]).mean() > 0)

--- a/tests/test_trace_subset_sampler.py
+++ b/tests/test_trace_subset_sampler.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from proc.util.datasets.trace_subset_sampler import (
+	TraceSubsetSampler,
+	TraceSubsetSamplerConfig,
+)
+
+
+def fake_info():
+	# key_to_indices: 2つの ffid グループ、それぞれ 5 本
+	ffid_vals = np.array(
+		[100, 100, 100, 100, 100, 101, 101, 101, 101, 101], dtype=np.int64
+	)
+	chno_vals = np.arange(10, dtype=np.int64)
+	offsets = np.linspace(0, 9, 10).astype(np.float32)
+	key_to_idx = {100: np.arange(0, 5), 101: np.arange(5, 10)}
+	uniq = [100, 101]
+	return {
+		'ffid_values': ffid_vals,
+		'chno_values': chno_vals,
+		'offsets': offsets,
+		'ffid_key_to_indices': key_to_idx,
+		'ffid_unique_keys': uniq,
+		# セントロイドなしで OK（index window fallback 動作を確認）
+		'ffid_centroids': None,
+	}
+
+
+def test_sampler_semantics_without_superwindow():
+	info = fake_info()
+	cfg = TraceSubsetSamplerConfig(
+		primary_keys=('ffid',),
+		primary_key_weights=(1.0,),
+		use_superwindow=False,
+		valid=True,
+		subset_traces=8,
+	)
+	sampler = TraceSubsetSampler(cfg)
+	out = sampler.draw(info)  # random は許容（仕様テスト）
+
+	# 仕様：出力項目
+	assert set(out.keys()) == {
+		'indices',
+		'pad_len',
+		'key_name',
+		'secondary_key',
+		'did_super',
+		'primary_unique',
+	}
+	idx = out['indices']
+	assert idx.dtype == np.int64
+	assert len(idx) <= 8
+	assert out['key_name'] == 'ffid'
+	assert out['secondary_key'] in {'chno', 'ffid', 'offset'}  # valid=True → "chno"
+	assert out['did_super'] in {False, True}  # 今回は False のはず


### PR DESCRIPTION
## Summary
- add a reusable TraceMasker and configuration for replace/add modes
- wire MaskedSegyGather to use the shared masker without changing outputs
- cover TraceMasker semantics with lightweight unit tests

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68eba92a36e4832b8a3e170218a0df88