### PR TITLE
Refactor FBLC gate into reusable module

### DIFF
--- a/proc/util/datasets/gate_fblc.py
+++ b/proc/util/datasets/gate_fblc.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FirstBreakGateConfig:
+        percentile: float = 95.0
+        thresh_ms: float = 8.0
+        min_pairs: int = 16
+        apply_on: Literal['any', 'super_only'] = 'any'
+        verbose: bool = False
+
+
+class FirstBreakGate:
+        def __init__(self, cfg: FirstBreakGateConfig):
+                if not (0.0 < float(cfg.percentile) < 100.0):
+                        raise ValueError('percentile must be in (0, 100)')
+                if not (float(cfg.thresh_ms) > 0.0):
+                        raise ValueError('thresh_ms must be positive')
+                if int(cfg.min_pairs) < 0:
+                        raise ValueError('min_pairs must be non-negative')
+                if cfg.apply_on not in ('any', 'super_only'):
+                        raise ValueError("apply_on must be 'any' or 'super_only'")
+                self.cfg = cfg
+
+        def should_apply(self, *, did_super: bool) -> bool:
+                if self.cfg.apply_on == 'any':
+                        return True
+                if self.cfg.apply_on == 'super_only':
+                        return bool(did_super)
+                return False
+
+        def accept(
+                self,
+                fb_idx_win: np.ndarray,
+                dt_eff_sec: float,
+                *,
+                did_super: bool,
+        ) -> tuple[bool, float | None, int]:
+                if not self.should_apply(did_super=did_super):
+                        return True, None, 0
+
+                v = fb_idx_win.astype(np.float64)
+                valid = v >= 0
+                m = valid[1:] & valid[:-1]
+                valid_pairs = int(m.sum())
+
+                if valid_pairs < int(self.cfg.min_pairs):
+                        return False, None, valid_pairs
+
+                diffs = np.abs(v[1:] - v[:-1])[m]
+                p = float(np.percentile(diffs, float(self.cfg.percentile)))
+                p_ms = p * float(dt_eff_sec) * 1000.0
+                ok = p_ms <= float(self.cfg.thresh_ms)
+                return ok, p_ms, valid_pairs

--- a/proc/util/datasets/gate_fblc.py
+++ b/proc/util/datasets/gate_fblc.py
@@ -25,10 +25,16 @@ class FirstBreakGate:
                         raise ValueError("apply_on must be 'any' or 'super_only'")
                 self.cfg = cfg
 
-        def should_apply(self, *, did_super: bool) -> bool:
-                if self.cfg.apply_on == 'any':
+        def should_apply(
+                self,
+                *,
+                did_super: bool,
+                apply_on: Literal['any', 'super_only'] | None = None,
+        ) -> bool:
+                ap = self.cfg.apply_on if apply_on is None else apply_on
+                if ap == 'any':
                         return True
-                if self.cfg.apply_on == 'super_only':
+                if ap == 'super_only':
                         return bool(did_super)
                 return False
 
@@ -38,8 +44,26 @@ class FirstBreakGate:
                 dt_eff_sec: float,
                 *,
                 did_super: bool,
+                percentile: float | None = None,
+                thresh_ms: float | None = None,
+                min_pairs: int | None = None,
+                apply_on: Literal['any', 'super_only'] | None = None,
         ) -> tuple[bool, float | None, int]:
-                if not self.should_apply(did_super=did_super):
+                p = self.cfg.percentile if percentile is None else float(percentile)
+                th = self.cfg.thresh_ms if thresh_ms is None else float(thresh_ms)
+                mp = self.cfg.min_pairs if min_pairs is None else int(min_pairs)
+                ap = self.cfg.apply_on if apply_on is None else apply_on
+
+                if not (0.0 < float(p) < 100.0):
+                        raise ValueError('percentile must be in (0, 100)')
+                if not (float(th) > 0.0):
+                        raise ValueError('thresh_ms must be positive')
+                if int(mp) < 0:
+                        raise ValueError('min_pairs must be non-negative')
+                if ap not in ('any', 'super_only'):
+                        raise ValueError("apply_on must be 'any' or 'super_only'")
+
+                if not self.should_apply(did_super=did_super, apply_on=ap):
                         return True, None, 0
 
                 v = fb_idx_win.astype(np.float64)
@@ -47,11 +71,11 @@ class FirstBreakGate:
                 m = valid[1:] & valid[:-1]
                 valid_pairs = int(m.sum())
 
-                if valid_pairs < int(self.cfg.min_pairs):
+                if valid_pairs < int(mp):
                         return False, None, valid_pairs
 
                 diffs = np.abs(v[1:] - v[:-1])[m]
-                p = float(np.percentile(diffs, float(self.cfg.percentile)))
-                p_ms = p * float(dt_eff_sec) * 1000.0
-                ok = p_ms <= float(self.cfg.thresh_ms)
+                q = float(np.percentile(diffs, float(p)))
+                p_ms = q * float(dt_eff_sec) * 1000.0
+                ok = p_ms <= float(th)
                 return ok, p_ms, valid_pairs

--- a/proc/util/datasets/masked_segy_gather.py
+++ b/proc/util/datasets/masked_segy_gather.py
@@ -556,15 +556,15 @@ class MaskedSegyGather(Dataset):
 			# FBLC gate (before masking/target/tensorization)
 			dt_eff_sec = info['dt_sec'] / max(factor, 1e-9)
 			if self.reject_fblc:
-                               ok, p_ms, valid_pairs = self.fblc_gate.accept(
-                                       fb_idx_win,
-                                       dt_eff_sec,
-                                       did_super=did_super,
-                                       percentile=self.fblc_percentile,
-                                       thresh_ms=self.fblc_thresh_ms,
-                                       min_pairs=self.fblc_min_pairs,
-                                       apply_on=self.fblc_apply_on,
-                               )
+				ok, p_ms, valid_pairs = self.fblc_gate.accept(
+					fb_idx_win,
+					dt_eff_sec,
+					did_super=did_super,
+					percentile=self.fblc_percentile,
+					thresh_ms=self.fblc_thresh_ms,
+					min_pairs=self.fblc_min_pairs,
+					apply_on=self.fblc_apply_on,
+				)
 				if not ok:
 					if self.verbose and p_ms is not None:
 						print(
@@ -574,9 +574,9 @@ class MaskedSegyGather(Dataset):
 					continue
 				if self.verbose and p_ms is not None:
 					print(
-							f'Accepted gather {info["path"]} key={key_name}:{key} '
-							f'for FBLC {p_ms:.1f}ms <= {self.fblc_thresh_ms}ms'
-						)
+						f'Accepted gather {info["path"]} key={key_name}:{key} '
+						f'for FBLC {p_ms:.1f}ms <= {self.fblc_thresh_ms}ms'
+					)
 
 			# masking (after acceptance)
 			x_masked, mask_idx = self.masker.apply(

--- a/proc/util/datasets/masked_segy_gather.py
+++ b/proc/util/datasets/masked_segy_gather.py
@@ -556,9 +556,15 @@ class MaskedSegyGather(Dataset):
 			# FBLC gate (before masking/target/tensorization)
 			dt_eff_sec = info['dt_sec'] / max(factor, 1e-9)
 			if self.reject_fblc:
-				ok, p_ms, valid_pairs = self.fblc_gate.accept(
-					fb_idx_win, dt_eff_sec, did_super=did_super
-				)
+                               ok, p_ms, valid_pairs = self.fblc_gate.accept(
+                                       fb_idx_win,
+                                       dt_eff_sec,
+                                       did_super=did_super,
+                                       percentile=self.fblc_percentile,
+                                       thresh_ms=self.fblc_thresh_ms,
+                                       min_pairs=self.fblc_min_pairs,
+                                       apply_on=self.fblc_apply_on,
+                               )
 				if not ok:
 					if self.verbose and p_ms is not None:
 						print(

--- a/tests/test_fblc_gate_runtime_override.py
+++ b/tests/test_fblc_gate_runtime_override.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from proc.util.datasets.gate_fblc import FirstBreakGate, FirstBreakGateConfig
+
+
+def test_runtime_override_thresh_ms_changes_decision():
+        fb = np.array([0, 20, 0, 20, 0, 20, 0, 20], dtype=np.int64)
+        gate = FirstBreakGate(
+                FirstBreakGateConfig(percentile=95.0, thresh_ms=1.0, min_pairs=3, apply_on="any")
+        )
+        ok1, p_ms1, pairs1 = gate.accept(fb, dt_eff_sec=0.001, did_super=False)
+        assert pairs1 >= 3 and (p_ms1 is not None) and (ok1 is False)
+
+        ok2, p_ms2, pairs2 = gate.accept(
+                fb,
+                dt_eff_sec=0.001,
+                did_super=False,
+                thresh_ms=10_000.0,
+        )
+        assert pairs2 == pairs1 and (p_ms2 is not None) and (ok2 is True)
+
+
+def test_runtime_override_apply_on_bypass_vs_force_apply():
+        fb = np.array([10, 11, 12, 13, 14, 15], dtype=np.int64)
+        gate = FirstBreakGate(FirstBreakGateConfig(apply_on="super_only", min_pairs=2, thresh_ms=1.0))
+        ok_bypass, p_ms_bypass, pairs_bypass = gate.accept(fb, dt_eff_sec=0.001, did_super=False)
+        assert ok_bypass is True and p_ms_bypass is None and pairs_bypass == 0
+
+        ok_force, p_ms_force, pairs_force = gate.accept(
+                fb,
+                dt_eff_sec=0.001,
+                did_super=False,
+                apply_on="any",
+        )
+        assert p_ms_force is not None and pairs_force > 0

--- a/tests/test_fblc_gate_semantics.py
+++ b/tests/test_fblc_gate_semantics.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from proc.util.datasets.gate_fblc import FirstBreakGate, FirstBreakGateConfig
+
+
+def test_fblc_accept_any():
+        fb = np.array([10, 11, 10, 11, 10, 11, 10, 11, 10, 11], dtype=np.int64)
+        gate = FirstBreakGate(
+                FirstBreakGateConfig(percentile=95.0, thresh_ms=8.0, min_pairs=4, apply_on="any")
+        )
+        ok, p_ms, pairs = gate.accept(fb, dt_eff_sec=0.001, did_super=False)
+        assert pairs >= 4 and ok and (p_ms is not None)
+
+
+def test_fblc_reject_large_jitter():
+        fb = np.array([10, 50, 10, 50, 10, 50, 10, 50, 10, 50], dtype=np.int64)
+        gate = FirstBreakGate(
+                FirstBreakGateConfig(percentile=95.0, thresh_ms=1.0, min_pairs=4, apply_on="any")
+        )
+        ok, p_ms, pairs = gate.accept(fb, dt_eff_sec=0.002, did_super=True)
+        assert pairs >= 4 and (p_ms is not None) and (not ok)
+
+
+def test_fblc_super_only_bypass_when_not_applied():
+        fb = np.array([-1, -1, 10, 10, 10, 10, -1, -1], dtype=np.int64)
+        gate = FirstBreakGate(FirstBreakGateConfig(apply_on="super_only"))
+        ok, p_ms, pairs = gate.accept(fb, dt_eff_sec=0.001, did_super=False)
+        assert ok and p_ms is None


### PR DESCRIPTION
## Summary
- extract the FBLC gating logic into a dedicated proc.util.datasets.gate_fblc module
- wire MaskedSegyGather to use the new FirstBreakGate helper without changing behaviour
- add a lightweight semantic test for the gate logic

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68ebb91e09a0832bb05155e2d25f7448