### PR TITLE
Refactor gather augmentations into reusable modules

### DIFF
--- a/proc/util/datasets/augment_freq.py
+++ b/proc/util/datasets/augment_freq.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+
+import numpy as np
+
+from proc.util.augment import _apply_freq_augment
+
+
+@dataclass(frozen=True)
+class FreqAugConfig:
+        prob: float = 0.0
+        kinds: tuple[str, ...] = ('bandpass', 'lowpass', 'highpass')
+        band: tuple[float, float] = (0.05, 0.45)
+        width: tuple[float, float] = (0.10, 0.35)
+        roll: float = 0.02
+        restandardize: bool = True
+
+
+class FreqAugmenter:
+        def __init__(self, config: FreqAugConfig | None = None) -> None:
+                self.config = config if config is not None else FreqAugConfig()
+
+        def apply(
+                self,
+                x: np.ndarray,
+                *,
+                rng_py: random.Random | None = None,
+                prob: float | None = None,
+                kinds: tuple[str, ...] | None = None,
+                band: tuple[float, float] | None = None,
+                width: tuple[float, float] | None = None,
+                roll: float | None = None,
+                restandardize: bool | None = None,
+        ) -> np.ndarray:
+                rng = rng_py if rng_py is not None else random
+                prob_eff = self.config.prob if prob is None else prob
+                if prob_eff <= 0.0 or rng.random() >= prob_eff:
+                        return x
+
+                kinds_eff = self.config.kinds if kinds is None else kinds
+                band_eff = self.config.band if band is None else band
+                width_eff = self.config.width if width is None else width
+                roll_eff = self.config.roll if roll is None else roll
+                restandardize_eff = (
+                        self.config.restandardize if restandardize is None else restandardize
+                )
+
+                x_aug = _apply_freq_augment(
+                        x,
+                        kinds_eff,
+                        band_eff,
+                        width_eff,
+                        roll_eff,
+                        restandardize_eff,
+                )
+                return np.asarray(x_aug, dtype=np.float32)

--- a/proc/util/datasets/augment_space.py
+++ b/proc/util/datasets/augment_space.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+
+import numpy as np
+
+from proc.util.augment import _spatial_stretch_sameH
+
+
+@dataclass(frozen=True)
+class SpaceAugConfig:
+        prob: float = 0.0
+        range: tuple[float, float] = (0.90, 1.10)
+
+
+class SpaceAugmenter:
+        def __init__(self, config: SpaceAugConfig | None = None) -> None:
+                self.config = config if config is not None else SpaceAugConfig()
+
+        def apply(
+                self,
+                x: np.ndarray,
+                offsets: np.ndarray,
+                *,
+                rng_py: random.Random | None = None,
+                prob: float | None = None,
+                range: tuple[float, float] | None = None,
+        ) -> tuple[np.ndarray, np.ndarray, bool, float]:
+                rng = rng_py if rng_py is not None else random
+                prob_eff = self.config.prob if prob is None else prob
+                if prob_eff <= 0.0 or rng.random() >= prob_eff:
+                        return x, offsets, False, 1.0
+
+                range_eff = self.config.range if range is None else range
+                f_h = rng.uniform(range_eff[0], range_eff[1])
+
+                x_aug = _spatial_stretch_sameH(x, f_h)
+                offsets_aug = _spatial_stretch_sameH(offsets[:, None], f_h)[:, 0]
+                return x_aug.astype(np.float32, copy=False), offsets_aug.astype(np.float32, copy=False), True, f_h

--- a/proc/util/datasets/augment_time.py
+++ b/proc/util/datasets/augment_time.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+import random
+import numpy as np
+from scipy.signal import resample_poly
+
+
+@dataclass(frozen=True)
+class TimeAugConfig:
+        prob: float = 0.0
+        range: tuple[float, float] = (0.95, 1.05)
+
+
+class TimeAugmenter:
+        def __init__(self, config: TimeAugConfig | None = None) -> None:
+                self.config = config if config is not None else TimeAugConfig()
+
+        def apply(
+                self,
+                x: np.ndarray,
+                *,
+                rng_py: random.Random | None = None,
+                prob: float | None = None,
+                range: tuple[float, float] | None = None,
+        ) -> tuple[np.ndarray, float]:
+                rng = rng_py if rng_py is not None else random
+                prob_eff = self.config.prob if prob is None else prob
+                if prob_eff <= 0.0 or rng.random() >= prob_eff:
+                        return x, 1.0
+
+                range_eff = self.config.range if range is None else range
+                factor = rng.uniform(range_eff[0], range_eff[1])
+                frac = Fraction(factor).limit_denominator(128)
+                up, down = frac.numerator, frac.denominator
+
+                traces = [
+                        resample_poly(trace, up, down, padtype='line') for trace in np.asarray(x)
+                ]
+                x_aug = np.stack(traces, axis=0).astype(np.float32, copy=False)
+                return x_aug, factor

--- a/proc/util/datasets/masked_segy_gather.py
+++ b/proc/util/datasets/masked_segy_gather.py
@@ -1,23 +1,20 @@
 import random
 import warnings
-from fractions import Fraction
 from pathlib import Path
 from typing import Literal
 
 import numpy as np
 import segyio
 import torch
-from scipy.signal import resample_poly
 from torch.utils.data import Dataset
 
-from proc.util.augment import (
-	_apply_freq_augment,
-	_spatial_stretch_sameH,
-)
 from proc.util.datasets.config import LoaderConfig, TraceSubsetSamplerConfig
 from proc.util.datasets.trace_subset_preproc import TraceSubsetLoader
 from proc.util.datasets.trace_subset_sampler import TraceSubsetSampler
 
+from .augment_freq import FreqAugConfig, FreqAugmenter
+from .augment_space import SpaceAugConfig, SpaceAugmenter
+from .augment_time import TimeAugConfig, TimeAugmenter
 from .gate_fblc import FirstBreakGate, FirstBreakGateConfig
 from .trace_masker import TraceMasker, TraceMaskerConfig
 from .target_fb import FBTargetConfig, FBTargetBuilder
@@ -220,6 +217,28 @@ class MaskedSegyGather(Dataset):
 		self.augment_freq_width = augment_freq_width
 		self.augment_freq_roll = augment_freq_roll
 		self.augment_freq_restandardize = augment_freq_restandardize
+		self.time_aug = TimeAugmenter(
+			TimeAugConfig(
+				prob=self.augment_time_prob,
+				range=self.augment_time_range,
+			)
+		)
+		self.space_aug = SpaceAugmenter(
+			SpaceAugConfig(
+				prob=self.augment_space_prob,
+				range=self.augment_space_range,
+			)
+		)
+		self.freq_aug = FreqAugmenter(
+			FreqAugConfig(
+				prob=self.augment_freq_prob,
+				kinds=self.augment_freq_kinds,
+				band=self.augment_freq_band,
+				width=self.augment_freq_width,
+				roll=self.augment_freq_roll,
+				restandardize=self.augment_freq_restandardize,
+			)
+		)
 		self.target_mode = target_mode
 		self.label_sigma = label_sigma
 		self.fb_target = FBTargetBuilder(
@@ -511,46 +530,37 @@ class MaskedSegyGather(Dataset):
 
 			# time augment
 			factor = 1.0
-			if self.augment_time_prob > 0 and random.random() < self.augment_time_prob:
-				factor = random.uniform(*self.augment_time_range)
-				frac = Fraction(factor).limit_denominator(128)
-				up, down = frac.numerator, frac.denominator
-				H_tmp = x.shape[0]
-				x = np.stack(
-					[
-						resample_poly(x[h], up, down, padtype='line')
-						for h in range(H_tmp)
-					],
-					axis=0,
-				)
+			x, factor = self.time_aug.apply(
+				x,
+				rng_py=random,
+				prob=self.augment_time_prob,
+				range=self.augment_time_range,
+			)
 
 			# fit/crop/pad time length
 			x, start = self._fit_time_len(x)
 
 			# space augment (and keep offsets in sync)
-			did_space = False
-			f_h = 1.0
-			if (
-				self.augment_space_prob > 0
-				and random.random() < self.augment_space_prob
-			):
-				f_h = random.uniform(*self.augment_space_range)
-				x = _spatial_stretch_sameH(x, f_h)
-				off_subset = _spatial_stretch_sameH(off_subset[:, None], f_h)[
-					:, 0
-				].astype(np.float32)
-				did_space = True
+			did_space, f_h = False, 1.0
+			x, off_subset, did_space, f_h = self.space_aug.apply(
+				x,
+				off_subset,
+				rng_py=random,
+				prob=self.augment_space_prob,
+				range=self.augment_space_range,
+			)
 
 			# freq augment
-			if self.augment_freq_prob > 0 and random.random() < self.augment_freq_prob:
-				x = _apply_freq_augment(
-					x,
-					self.augment_freq_kinds,
-					self.augment_freq_band,
-					self.augment_freq_width,
-					self.augment_freq_roll,
-					self.augment_freq_restandardize,
-				)
+			x = self.freq_aug.apply(
+				x,
+				rng_py=random,
+				prob=self.augment_freq_prob,
+				kinds=self.augment_freq_kinds,
+				band=self.augment_freq_band,
+				width=self.augment_freq_width,
+				roll=self.augment_freq_roll,
+				restandardize=self.augment_freq_restandardize,
+			)
 
 			# first-break indices in window
 			fb_idx_win = np.floor(fb_subset * factor).astype(np.int64) - start

--- a/tests/test_augment_freq_semantics.py
+++ b/tests/test_augment_freq_semantics.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+from proc.util.datasets.augment_freq import FreqAugConfig, FreqAugmenter
+
+
+def test_freq_aug_noop_when_prob_zero():
+        H, W = 8, 64
+        x = np.random.randn(H, W).astype(np.float32)
+        aug = FreqAugmenter(FreqAugConfig(prob=0.0))
+        y = aug.apply(x, rng_py=None)
+        np.testing.assert_allclose(y, x, atol=0, rtol=0)

--- a/tests/test_augment_space_semantics.py
+++ b/tests/test_augment_space_semantics.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from proc.util.datasets.augment_space import SpaceAugConfig, SpaceAugmenter
+
+
+def test_space_aug_noop_when_prob_zero():
+        H, W = 8, 32
+        x = np.random.randn(H, W).astype(np.float32)
+        off = np.linspace(0, 1, H).astype(np.float32)
+        aug = SpaceAugmenter(SpaceAugConfig(prob=0.0))
+        y, off2, did, f = aug.apply(x, off, rng_py=None)
+        assert did is False and f == 1.0
+        np.testing.assert_allclose(y, x, atol=0, rtol=0)
+        np.testing.assert_allclose(off2, off, atol=0, rtol=0)

--- a/tests/test_augment_time_semantics.py
+++ b/tests/test_augment_time_semantics.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from proc.util.datasets.augment_time import TimeAugConfig, TimeAugmenter
+
+
+def test_time_aug_noop_when_prob_zero():
+        H, W = 4, 64
+        x = np.random.randn(H, W).astype(np.float32)
+        aug = TimeAugmenter(TimeAugConfig(prob=0.0))
+        y, factor = aug.apply(x, rng_py=None)
+        assert factor == 1.0
+        np.testing.assert_allclose(y, x, atol=0, rtol=0)


### PR DESCRIPTION
## Summary
- extract the time, space, and frequency augmentations into dedicated modules that preserve existing behavior and allow runtime overrides
- instantiate the new augmenters inside `MaskedSegyGather` and route dataset attributes through them each iteration
- add semantic smoke tests that verify each augmentation is a no-op when probability is zero

## Testing
- pytest -q *(fails: missing numpy in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebd5e05ee8832bae216a1e7d5abd6a